### PR TITLE
feat: add user geolocation

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15
+        image: postgis/postgis:16-3.5
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/backend/migrations/004_add_location_to_users.sql
+++ b/backend/migrations/004_add_location_to_users.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+ALTER TABLE users
+  ADD COLUMN location GEOGRAPHY(Point,4326),
+  ADD COLUMN search_radius INTEGER;
+
+CREATE INDEX users_location_idx ON users USING GIST (location);

--- a/backend/src/repositories/userRepository.ts
+++ b/backend/src/repositories/userRepository.ts
@@ -2,6 +2,18 @@ import { query } from '../db.js';
 import bcrypt from 'bcryptjs';
 import { DEFAULT_USER_LANGUAGE, DEFAULT_USER_ROLE } from '../constants.js';
 
+interface UserRow {
+  id: number;
+  name: string;
+  email: string;
+  password: string;
+  role: string;
+  language: string;
+  longitude: number | null;
+  latitude: number | null;
+  search_radius: number | null;
+}
+
 export interface User {
   id: number;
   name: string;
@@ -9,6 +21,18 @@ export interface User {
   password: string;
   role: string;
   language: string;
+  location: { latitude: number; longitude: number } | null;
+  searchRadius: number | null;
+}
+
+function rowToUser(row: UserRow): User {
+  const { longitude, latitude, search_radius, ...rest } = row;
+  return {
+    ...rest,
+    location:
+      longitude !== null && latitude !== null ? { latitude, longitude } : null,
+    searchRadius: search_radius,
+  };
 }
 
 export type PublicUser = Omit<User, 'password'>;
@@ -20,15 +44,19 @@ export function toPublicUser(user: User): PublicUser {
 }
 
 export async function findUserByEmail(email: string): Promise<User | null> {
-  const { rows } = await query<User>('SELECT * FROM users WHERE email = $1', [
-    email,
-  ]);
-  return rows[0] ?? null;
+  const { rows } = await query<UserRow>(
+    'SELECT *, ST_X(location::geometry) AS longitude, ST_Y(location::geometry) AS latitude FROM users WHERE email = $1',
+    [email]
+  );
+  return rows[0] ? rowToUser(rows[0]) : null;
 }
 
 export async function findUserById(id: number): Promise<User | null> {
-  const { rows } = await query<User>('SELECT * FROM users WHERE id = $1', [id]);
-  return rows[0] ?? null;
+  const { rows } = await query<UserRow>(
+    'SELECT *, ST_X(location::geometry) AS longitude, ST_Y(location::geometry) AS latitude FROM users WHERE id = $1',
+    [id]
+  );
+  return rows[0] ? rowToUser(rows[0]) : null;
 }
 
 export async function createUser(
@@ -39,20 +67,33 @@ export async function createUser(
   language = DEFAULT_USER_LANGUAGE
 ): Promise<User> {
   const hashed = await bcrypt.hash(password, 10);
-  const { rows } = await query<User>(
-    'INSERT INTO users (name, email, password, role, language) VALUES ($1, $2, $3, $4, $5) RETURNING *',
+  const { rows } = await query<UserRow>(
+    'INSERT INTO users (name, email, password, role, language) VALUES ($1, $2, $3, $4, $5) RETURNING *, ST_X(location::geometry) AS longitude, ST_Y(location::geometry) AS latitude',
     [name, email, hashed, role, language]
   );
-  return rows[0];
+  return rowToUser(rows[0]);
 }
 
 export async function updateUserLanguage(
   id: number,
   language: string
 ): Promise<User> {
-  const { rows } = await query<User>(
-    'UPDATE users SET language = $1 WHERE id = $2 RETURNING *',
+  const { rows } = await query<UserRow>(
+    'UPDATE users SET language = $1 WHERE id = $2 RETURNING *, ST_X(location::geometry) AS longitude, ST_Y(location::geometry) AS latitude',
     [language, id]
   );
-  return rows[0];
+  return rowToUser(rows[0]);
+}
+
+export async function updateUserLocation(
+  id: number,
+  longitude: number,
+  latitude: number,
+  searchRadius: number
+): Promise<User> {
+  const { rows } = await query<UserRow>(
+    'UPDATE users SET location = ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, search_radius = $3 WHERE id = $4 RETURNING *, ST_X(location::geometry) AS longitude, ST_Y(location::geometry) AS latitude',
+    [longitude, latitude, searchRadius, id]
+  );
+  return rowToUser(rows[0]);
 }

--- a/backend/tests/repositories/userRepository.test.ts
+++ b/backend/tests/repositories/userRepository.test.ts
@@ -7,6 +7,7 @@ import {
   findUserByEmail,
   findUserById,
   updateUserLanguage,
+  updateUserLocation,
 } from '../../src/repositories/userRepository.js';
 import {
   DEFAULT_USER_ROLE,
@@ -51,5 +52,21 @@ describe('userRepository', () => {
     await updateUserLanguage(user.id, 'en');
     const updated = await findUserById(user.id);
     expect(updated?.language).toBe('en');
+  });
+
+  test('updates user location and search radius', async () => {
+    const user = await createUser(
+      'Carol',
+      'carol@example.com',
+      'secret',
+      DEFAULT_USER_ROLE
+    );
+    await updateUserLocation(user.id, -3.7038, 40.4168, 1000);
+    const updated = await findUserById(user.id);
+    expect(updated?.location).toEqual({
+      latitude: 40.4168,
+      longitude: -3.7038,
+    });
+    expect(updated?.searchRadius).toBe(1000);
   });
 });


### PR DESCRIPTION
## Summary
- add migration to store user location and search radius
- support location fields and index in repository
- test updating user location
- fix longitude/latitude parameter order when updating location and signature
- cast location updates to geography
- use PostGIS 16-3.5 image in backend workflow so migrations run

## Testing
- `npm run complete-check`
- `npm test -w backend`
- `npm test -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68c618fff7a0832eb7d10c8e2d2745bb