### PR TITLE
Add book search and verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,11 @@ Estas instrucciones aplican a todo el repositorio.
 - Usa `rg` para buscar en el código en lugar de `grep` o `ls -R`.
 - Los archivos se formatean automáticamente con Prettier; evita editar el formato manualmente.
 - Los mensajes de commit deben ser claros, en tiempo presente y concisos.
+- Las respuestas de error deben incluir claves de traducción para i18n, por ejemplo `{ error: 'Code', message: 'namespace.key' }`.
+- Evita usar el tipo `any`; prefiere tipos específicos.
+
+## Buenas prácticas
+- Mantén la lógica de acceso a datos en repositorios dedicados y las rutas enfocadas en la capa HTTP.
 
 ## AGENTS anidados
 Si modificas archivos dentro de un directorio que contenga su propio `AGENTS.md`, respeta las instrucciones adicionales de ese archivo.

--- a/backend/migrations/004_add_book_fields.sql
+++ b/backend/migrations/004_add_book_fields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE books
+  ADD COLUMN author TEXT,
+  ADD COLUMN isbn TEXT,
+  ADD COLUMN published_year INTEGER,
+  ADD COLUMN publisher TEXT,
+  ADD COLUMN verified BOOLEAN NOT NULL DEFAULT false;

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -256,8 +256,19 @@
     },
     "/api/books": {
       "get": {
-        "summary": "List all books",
+        "summary": "List or search books",
         "tags": ["Books"],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Search query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Array of books",
@@ -266,15 +277,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "title": {
-                        "type": "string"
-                      }
-                    }
+                    "$ref": "#/components/schemas/Book"
                   }
                 }
               }
@@ -291,9 +294,21 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["title"],
+                "required": ["title", "author"],
                 "properties": {
                   "title": {
+                    "type": "string"
+                  },
+                  "author": {
+                    "type": "string"
+                  },
+                  "isbn": {
+                    "type": "string"
+                  },
+                  "publishedYear": {
+                    "type": "integer"
+                  },
+                  "publisher": {
                     "type": "string"
                   }
                 }
@@ -307,26 +322,115 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/Book"
                 }
               }
             }
           },
           "400": {
-            "description": "title is required"
+            "description": "Missing required fields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "MissingFields"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "books.errors.missing_title_author"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/books/{id}/verify": {
+      "post": {
+        "summary": "Verify a book",
+        "tags": ["Books"],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Book verified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Book"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Book not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "BookNotFound"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "books.errors.not_found"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
     }
   },
-  "components": {},
+  "components": {
+    "schemas": {
+      "Book": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "isbn": {
+            "type": "string",
+            "nullable": true
+          },
+          "published_year": {
+            "type": "integer",
+            "nullable": true
+          },
+          "publisher": {
+            "type": "string",
+            "nullable": true
+          },
+          "verified": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  },
   "tags": []
 }

--- a/backend/src/repositories/bookRepository.ts
+++ b/backend/src/repositories/bookRepository.ts
@@ -3,17 +3,66 @@ import { query } from '../db.js';
 export interface Book {
   id: number;
   title: string;
+  author: string | null;
+  isbn: string | null;
+  published_year: number | null;
+  publisher: string | null;
+  verified: boolean;
 }
 
-export async function createBook(title: string): Promise<Book> {
+export interface CreateBookInput {
+  title: string;
+  author: string;
+  isbn?: string;
+  publishedYear?: number;
+  publisher?: string;
+}
+
+export async function createBook({
+  title,
+  author,
+  isbn,
+  publishedYear,
+  publisher,
+}: CreateBookInput): Promise<Book> {
+  const autoVerified = isbn ? /^\d{13}$/.test(isbn) : false;
   const { rows } = await query<Book>(
-    'INSERT INTO books (title) VALUES ($1) RETURNING *',
-    [title]
+    `INSERT INTO books (title, author, isbn, published_year, publisher, verified)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+    [
+      title,
+      author,
+      isbn ?? null,
+      publishedYear ?? null,
+      publisher ?? null,
+      autoVerified,
+    ]
   );
   return rows[0];
 }
 
 export async function listBooks(): Promise<Book[]> {
-  const { rows } = await query<Book>('SELECT * FROM books ORDER BY id');
+  const { rows } = await query<Book>(
+    'SELECT * FROM books WHERE verified = true ORDER BY id'
+  );
   return rows;
+}
+
+export async function searchBooks(queryText: string): Promise<Book[]> {
+  const { rows } = await query<Book>(
+    `SELECT * FROM books
+     WHERE verified = true AND (title ILIKE $1 OR author ILIKE $1)
+     ORDER BY id`,
+    [`%${queryText}%`]
+  );
+  return rows;
+}
+
+export async function verifyBook(id: number): Promise<Book | null> {
+  const { rows } = await query<Book>(
+    'UPDATE books SET verified = true WHERE id = $1 RETURNING *',
+    [id]
+  );
+  return rows[0] ?? null;
 }

--- a/backend/src/routes/books.ts
+++ b/backend/src/routes/books.ts
@@ -1,20 +1,53 @@
 import { Router } from 'express';
-import { createBook, listBooks } from '../repositories/bookRepository.js';
+import {
+  createBook,
+  listBooks,
+  searchBooks,
+  verifyBook,
+} from '../repositories/bookRepository.js';
 
 const router = Router();
 
-router.get('/', async (_req, res) => {
-  const books = await listBooks();
+router.get('/', async (req, res) => {
+  const { q } = req.query as { q?: string };
+  const books = q ? await searchBooks(q) : await listBooks();
   res.json(books);
 });
 
 router.post('/', async (req, res) => {
-  const { title } = req.body as { title?: string };
-  if (!title) {
-    return res.status(400).json({ error: 'title is required' });
+  const { title, author, isbn, publishedYear, publisher } = req.body as {
+    title?: string;
+    author?: string;
+    isbn?: string;
+    publishedYear?: number;
+    publisher?: string;
+  };
+  if (!title || !author) {
+    return res.status(400).json({
+      error: 'MissingFields',
+      message: 'books.errors.missing_title_author',
+    });
   }
-  const book = await createBook(title);
+  const book = await createBook({
+    title,
+    author,
+    isbn,
+    publishedYear,
+    publisher,
+  });
   res.status(201).json(book);
+});
+
+router.post('/:id/verify', async (req, res) => {
+  const { id } = req.params;
+  const book = await verifyBook(Number(id));
+  if (!book) {
+    return res.status(404).json({
+      error: 'BookNotFound',
+      message: 'books.errors.not_found',
+    });
+  }
+  res.json(book);
 });
 
 export default router;

--- a/backend/tests/repositories/bookRepository.test.ts
+++ b/backend/tests/repositories/bookRepository.test.ts
@@ -3,6 +3,8 @@ import { pool, setTestClient } from '../../src/db.js';
 import {
   createBook,
   listBooks,
+  verifyBook,
+  searchBooks,
 } from '../../src/repositories/bookRepository.js';
 import type { PoolClient } from 'pg';
 
@@ -21,10 +23,16 @@ afterEach(async () => {
 });
 
 describe('bookRepository', () => {
-  test('inserts and lists books', async () => {
-    await createBook('Test Book');
-    const books = await listBooks();
+  test('inserts, verifies and searches books', async () => {
+    const created = await createBook({ title: 'Test Book', author: 'Tester' });
+    expect(created.verified).toBe(false);
+    let books = await listBooks();
+    expect(books).toHaveLength(0);
+    await verifyBook(created.id);
+    books = await listBooks();
     expect(books).toHaveLength(1);
     expect(books[0].title).toBe('Test Book');
+    const found = await searchBooks('Test');
+    expect(found).toHaveLength(1);
   });
 });

--- a/backend/tests/routes/books.api.test.ts
+++ b/backend/tests/routes/books.api.test.ts
@@ -19,13 +19,38 @@ afterEach(async () => {
 });
 
 describe('books API', () => {
-  test('creates and lists books via HTTP', async () => {
-    await request(app)
+  test('creates, verifies and searches books via HTTP', async () => {
+    const createRes = await request(app)
       .post('/api/books')
-      .send({ title: 'API Book' })
+      .send({ title: 'API Book', author: 'Author' })
       .expect(201);
-    const res = await request(app).get('/api/books').expect(200);
+    expect(createRes.body.verified).toBe(false);
+
+    let res = await request(app).get('/api/books').expect(200);
+    expect(res.body).toHaveLength(0);
+
+    await request(app)
+      .post(`/api/books/${createRes.body.id}/verify`)
+      .expect(200);
+
+    res = await request(app).get('/api/books?q=API').expect(200);
     expect(res.body).toHaveLength(1);
-    expect(res.body[0].title).toBe('API Book');
+    expect(res.body[0].verified).toBe(true);
+  });
+
+  test('returns i18n errors for missing fields and not found', async () => {
+    const missing = await request(app).post('/api/books').send({}).expect(400);
+    expect(missing.body).toEqual({
+      error: 'MissingFields',
+      message: 'books.errors.missing_title_author',
+    });
+
+    const notFound = await request(app)
+      .post('/api/books/999/verify')
+      .expect(404);
+    expect(notFound.body).toEqual({
+      error: 'BookNotFound',
+      message: 'books.errors.not_found',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend books table with bibliographic fields and verified flag
- support pending book creation, search and admin verification
- document endpoints in OpenAPI
- format book errors for i18n and document i18n/no-any guidelines

## Testing
- `npm run complete-check` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68c619108120832e9f2dcdb60a3e7a01