### PR TITLE
Add book verification and OpenLibrary integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Estas instrucciones aplican a todo el repositorio.
 - Usa `rg` para buscar en el código en lugar de `grep` o `ls -R`.
 - Los archivos se formatean automáticamente con Prettier; evita editar el formato manualmente.
 - Los mensajes de commit deben ser claros, en tiempo presente y concisos.
+- Evita usar el tipo `any`; utiliza tipos explícitos o `unknown` cuando sea necesario.
 
 ## AGENTS anidados
 Si modificas archivos dentro de un directorio que contenga su propio `AGENTS.md`, respeta las instrucciones adicionales de ese archivo.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,3 +1,4 @@
 # AGENTS
 
 Todos los errores enviados al frontend deben expresarse como claves de i18n.
+Evita usar el tipo `any`; utiliza tipos explícitos o `unknown` cuando sea necesario.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS
+
+Todos los errores enviados al frontend deben expresarse como claves de i18n.

--- a/backend/migrations/005_add_book_fields.sql
+++ b/backend/migrations/005_add_book_fields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE books
+  ADD COLUMN author TEXT,
+  ADD COLUMN isbn TEXT,
+  ADD COLUMN publisher TEXT,
+  ADD COLUMN published_year INT,
+  ADD COLUMN verified BOOLEAN NOT NULL DEFAULT false;

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -273,6 +273,21 @@
                       },
                       "title": {
                         "type": "string"
+                      },
+                      "author": {
+                        "type": ["string", "null"]
+                      },
+                      "isbn": {
+                        "type": ["string", "null"]
+                      },
+                      "publisher": {
+                        "type": ["string", "null"]
+                      },
+                      "publishedYear": {
+                        "type": ["integer", "null"]
+                      },
+                      "verified": {
+                        "type": "boolean"
                       }
                     }
                   }
@@ -295,6 +310,18 @@
                 "properties": {
                   "title": {
                     "type": "string"
+                  },
+                  "author": {
+                    "type": "string"
+                  },
+                  "isbn": {
+                    "type": "string"
+                  },
+                  "publisher": {
+                    "type": "string"
+                  },
+                  "publishedYear": {
+                    "type": "integer"
                   }
                 }
               }
@@ -314,6 +341,21 @@
                     },
                     "title": {
                       "type": "string"
+                    },
+                    "author": {
+                      "type": ["string", "null"]
+                    },
+                    "isbn": {
+                      "type": ["string", "null"]
+                    },
+                    "publisher": {
+                      "type": ["string", "null"]
+                    },
+                    "publishedYear": {
+                      "type": ["integer", "null"]
+                    },
+                    "verified": {
+                      "type": "boolean"
                     }
                   }
                 }
@@ -321,7 +363,112 @@
             }
           },
           "400": {
-            "description": "title is required"
+            "description": "books.errors.title_required"
+          }
+        }
+      }
+    },
+    "/api/books/search": {
+      "get": {
+        "summary": "Search books via OpenLibrary",
+        "tags": ["Books"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of books",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "title": {
+                        "type": "string"
+                      },
+                      "author": {
+                        "type": ["string", "null"]
+                      },
+                      "isbn": {
+                        "type": ["string", "null"]
+                      },
+                      "publisher": {
+                        "type": ["string", "null"]
+                      },
+                      "publishedYear": {
+                        "type": ["integer", "null"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "books.errors.q_required"
+          }
+        }
+      }
+    },
+    "/api/books/{id}/verify": {
+      "post": {
+        "summary": "Verify a book",
+        "tags": ["Books"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Book verified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "author": {
+                      "type": ["string", "null"]
+                    },
+                    "isbn": {
+                      "type": ["string", "null"]
+                    },
+                    "publisher": {
+                      "type": ["string", "null"]
+                    },
+                    "publishedYear": {
+                      "type": ["integer", "null"]
+                    },
+                    "verified": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "books.errors.not_found"
           }
         }
       }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -415,6 +415,9 @@
           },
           "400": {
             "description": "books.errors.q_required"
+          },
+          "502": {
+            "description": "books.errors.search_failed"
           }
         }
       }

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -19,7 +19,7 @@ export function getClient(): Pool | PoolClient {
 
 export async function query<T extends QueryResultRow = QueryResultRow>(
   sql: string,
-  params?: any[]
+  params?: unknown[]
 ): Promise<{ rows: T[] }> {
   const client = getClient();
   // Both Pool and PoolClient expose a compatible query method

--- a/backend/src/repositories/bookRepository.ts
+++ b/backend/src/repositories/bookRepository.ts
@@ -1,19 +1,71 @@
 import { query } from '../db.js';
 
+interface BookRow {
+  id: number;
+  title: string;
+  author: string | null;
+  isbn: string | null;
+  publisher: string | null;
+  published_year: number | null;
+  verified: boolean;
+}
+
 export interface Book {
   id: number;
   title: string;
+  author: string | null;
+  isbn: string | null;
+  publisher: string | null;
+  publishedYear: number | null;
+  verified: boolean;
 }
 
-export async function createBook(title: string): Promise<Book> {
-  const { rows } = await query<Book>(
-    'INSERT INTO books (title) VALUES ($1) RETURNING *',
-    [title]
+function rowToBook(row: BookRow): Book {
+  const { published_year, ...rest } = row;
+  return { ...rest, publishedYear: published_year };
+}
+
+export interface NewBook {
+  title: string;
+  author?: string | null;
+  isbn?: string | null;
+  publisher?: string | null;
+  publishedYear?: number | null;
+  verified?: boolean;
+}
+
+export async function createBook(book: NewBook): Promise<Book> {
+  const {
+    title,
+    author,
+    isbn,
+    publisher,
+    publishedYear,
+    verified = false,
+  } = book;
+  const { rows } = await query<BookRow>(
+    'INSERT INTO books (title, author, isbn, publisher, published_year, verified) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
+    [
+      title,
+      author ?? null,
+      isbn ?? null,
+      publisher ?? null,
+      publishedYear ?? null,
+      verified,
+    ]
   );
-  return rows[0];
+  return rowToBook(rows[0]);
 }
 
 export async function listBooks(): Promise<Book[]> {
-  const { rows } = await query<Book>('SELECT * FROM books ORDER BY id');
-  return rows;
+  const { rows } = await query<BookRow>('SELECT * FROM books ORDER BY id');
+  return rows.map(rowToBook);
+}
+
+export async function verifyBook(id: number): Promise<Book | null> {
+  const { rows } = await query<BookRow>(
+    'UPDATE books SET verified = true WHERE id = $1 RETURNING *',
+    [id]
+  );
+  return rows[0] ? rowToBook(rows[0]) : null;
 }

--- a/backend/src/routes/books.ts
+++ b/backend/src/routes/books.ts
@@ -1,5 +1,14 @@
 import { Router } from 'express';
-import { createBook, listBooks } from '../repositories/bookRepository.js';
+import {
+  createBook,
+  listBooks,
+  verifyBook,
+  NewBook,
+} from '../repositories/bookRepository.js';
+import {
+  searchBooks as searchExternalBooks,
+  checkBookExists,
+} from '../services/openLibrary.js';
 
 const router = Router();
 
@@ -8,13 +17,52 @@ router.get('/', async (_req, res) => {
   res.json(books);
 });
 
-router.post('/', async (req, res) => {
-  const { title } = req.body as { title?: string };
-  if (!title) {
-    return res.status(400).json({ error: 'title is required' });
+router.get('/search', async (req, res) => {
+  const q = req.query.q as string | undefined;
+  if (!q) {
+    return res.status(400).json({
+      error: 'MissingFields',
+      message: 'books.errors.q_required',
+    });
   }
-  const book = await createBook(title);
+  const books = await searchExternalBooks(q);
+  res.json(books);
+});
+
+router.post('/', async (req, res) => {
+  const { title, author, isbn, publisher, publishedYear } = req.body as NewBook;
+  if (!title) {
+    return res.status(400).json({
+      error: 'MissingFields',
+      message: 'books.errors.title_required',
+    });
+  }
+  const verified = await checkBookExists({
+    title,
+    author: author ?? undefined,
+    isbn: isbn ?? undefined,
+  });
+  const book = await createBook({
+    title,
+    author,
+    isbn,
+    publisher,
+    publishedYear,
+    verified,
+  });
   res.status(201).json(book);
+});
+
+router.post('/:id/verify', async (req, res) => {
+  const id = Number(req.params.id);
+  const book = await verifyBook(id);
+  if (!book) {
+    return res.status(404).json({
+      error: 'NotFound',
+      message: 'books.errors.not_found',
+    });
+  }
+  res.json(book);
 });
 
 export default router;

--- a/backend/src/routes/books.ts
+++ b/backend/src/routes/books.ts
@@ -25,8 +25,15 @@ router.get('/search', async (req, res) => {
       message: 'books.errors.q_required',
     });
   }
-  const books = await searchExternalBooks(q);
-  res.json(books);
+  try {
+    const books = await searchExternalBooks(q);
+    res.json(books);
+  } catch {
+    res.status(502).json({
+      error: 'SearchFailed',
+      message: 'books.errors.search_failed',
+    });
+  }
 });
 
 router.post('/', async (req, res) => {

--- a/backend/src/services/openLibrary.ts
+++ b/backend/src/services/openLibrary.ts
@@ -1,0 +1,49 @@
+export interface OpenLibraryBook {
+  title: string;
+  author: string | null;
+  isbn: string | null;
+  publisher: string | null;
+  publishedYear: number | null;
+}
+
+export async function searchBooks(query: string): Promise<OpenLibraryBook[]> {
+  const url = `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=10`;
+  const res = await fetch(url);
+  const data = await res.json();
+  return (data.docs ?? []).map((doc: any) => ({
+    title: doc.title,
+    author: doc.author_name ? doc.author_name[0] : null,
+    isbn: doc.isbn ? doc.isbn[0] : null,
+    publisher: doc.publisher ? doc.publisher[0] : null,
+    publishedYear: doc.first_publish_year ?? null,
+  }));
+}
+
+export async function checkBookExists(params: {
+  title?: string;
+  author?: string;
+  isbn?: string;
+}): Promise<boolean> {
+  if (process.env.NODE_ENV === 'test') {
+    return false;
+  }
+  let query = '';
+  if (params.isbn) {
+    query = `isbn:${params.isbn}`;
+  } else if (params.title) {
+    query = params.title;
+    if (params.author) {
+      query += ` ${params.author}`;
+    }
+  } else {
+    return false;
+  }
+  const url = `https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=1`;
+  try {
+    const res = await fetch(url);
+    const data = await res.json();
+    return (data.numFound ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}

--- a/backend/src/services/openLibrary.ts
+++ b/backend/src/services/openLibrary.ts
@@ -41,14 +41,11 @@ export async function checkBookExists(
   options?: { fetchFn?: typeof fetch }
 ): Promise<boolean> {
   const fetchFn = options?.fetchFn ?? fetch;
-  let query = '';
+  let query: string;
   if (params.isbn) {
     query = `isbn:${params.isbn}`;
   } else if (params.title) {
-    query = params.title;
-    if (params.author) {
-      query += ` ${params.author}`;
-    }
+    query = params.author ? `${params.title} ${params.author}` : params.title;
   } else {
     return false;
   }

--- a/backend/src/socket.ts
+++ b/backend/src/socket.ts
@@ -50,23 +50,23 @@ export function setupWebsocket(
 ) {
   io.use(async (socket, next) => {
     const jwtSecret = process.env.JWT_SECRET;
-    if (!jwtSecret) return next(new Error('Unauthorized'));
+    if (!jwtSecret) return next(new Error('auth.errors.unauthorized'));
     const jwtAlgorithm = (process.env.JWT_ALGORITHM || 'HS256') as Algorithm;
     const token = parseCookies(socket.handshake.headers.cookie).sessionToken;
-    if (!token) return next(new Error('Unauthorized'));
+    if (!token) return next(new Error('auth.errors.unauthorized'));
     try {
       const payload = jwt.verify(token, jwtSecret, {
         algorithms: [jwtAlgorithm],
       }) as { id: number };
       const user = await findUserById(payload.id);
-      if (!user) return next(new Error('Unauthorized'));
+      if (!user) return next(new Error('auth.errors.unauthorized'));
       socket.data.user = { id: user.id, name: user.name };
       next();
     } catch (error) {
       logger.error('Socket authentication error', {
         message: error instanceof Error ? error.message : String(error),
       });
-      next(new Error('Unauthorized'));
+      next(new Error('auth.errors.unauthorized'));
     }
   });
 

--- a/backend/tests/repositories/bookRepository.test.ts
+++ b/backend/tests/repositories/bookRepository.test.ts
@@ -3,6 +3,7 @@ import { pool, setTestClient } from '../../src/db.js';
 import {
   createBook,
   listBooks,
+  verifyBook,
 } from '../../src/repositories/bookRepository.js';
 import type { PoolClient } from 'pg';
 
@@ -21,10 +22,17 @@ afterEach(async () => {
 });
 
 describe('bookRepository', () => {
-  test('inserts and lists books', async () => {
-    await createBook('Test Book');
+  test('inserts and lists books with pending verification', async () => {
+    await createBook({ title: 'Test Book', author: 'Author' });
     const books = await listBooks();
     expect(books).toHaveLength(1);
     expect(books[0].title).toBe('Test Book');
+    expect(books[0].verified).toBe(false);
+  });
+
+  test('marks book as verified', async () => {
+    const book = await createBook({ title: 'Another Book' });
+    const verified = await verifyBook(book.id);
+    expect(verified?.verified).toBe(true);
   });
 });

--- a/backend/tests/routes/books.api.test.ts
+++ b/backend/tests/routes/books.api.test.ts
@@ -19,13 +19,44 @@ afterEach(async () => {
 });
 
 describe('books API', () => {
-  test('creates and lists books via HTTP', async () => {
-    await request(app)
+  test('creates, lists and verifies books via HTTP', async () => {
+    const createRes = await request(app)
       .post('/api/books')
       .send({ title: 'API Book' })
       .expect(201);
+    expect(createRes.body.verified).toBe(false);
+
     const res = await request(app).get('/api/books').expect(200);
     expect(res.body).toHaveLength(1);
     expect(res.body[0].title).toBe('API Book');
+
+    const verifyRes = await request(app)
+      .post(`/api/books/${createRes.body.id}/verify`)
+      .expect(200);
+    expect(verifyRes.body.verified).toBe(true);
+  });
+
+  test('requires q for search', async () => {
+    const res = await request(app).get('/api/books/search').expect(400);
+    expect(res.body).toEqual({
+      error: 'MissingFields',
+      message: 'books.errors.q_required',
+    });
+  });
+
+  test('requires title when creating book', async () => {
+    const res = await request(app).post('/api/books').send({}).expect(400);
+    expect(res.body).toEqual({
+      error: 'MissingFields',
+      message: 'books.errors.title_required',
+    });
+  });
+
+  test('returns not found when verifying missing book', async () => {
+    const res = await request(app).post('/api/books/123/verify').expect(404);
+    expect(res.body).toEqual({
+      error: 'NotFound',
+      message: 'books.errors.not_found',
+    });
   });
 });

--- a/backend/tests/routes/books.api.test.ts
+++ b/backend/tests/routes/books.api.test.ts
@@ -47,6 +47,18 @@ describe('books API', () => {
     });
   });
 
+  test('returns search error when OpenLibrary fails', async () => {
+    vi.spyOn(openLibrary, 'searchBooks').mockRejectedValue(new Error('fail'));
+    const res = await request(app)
+      .get('/api/books/search')
+      .query({ q: 'foo' })
+      .expect(502);
+    expect(res.body).toEqual({
+      error: 'SearchFailed',
+      message: 'books.errors.search_failed',
+    });
+  });
+
   test('requires title when creating book', async () => {
     const res = await request(app).post('/api/books').send({}).expect(400);
     expect(res.body).toEqual({

--- a/backend/tests/routes/books.api.test.ts
+++ b/backend/tests/routes/books.api.test.ts
@@ -1,8 +1,9 @@
 import request from 'supertest';
-import { beforeEach, afterEach, describe, expect, test } from 'vitest';
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest';
 import app from '../../src/app.js';
 import { pool, setTestClient } from '../../src/db.js';
 import type { PoolClient } from 'pg';
+import * as openLibrary from '../../src/services/openLibrary.js';
 
 let client: PoolClient;
 
@@ -10,12 +11,14 @@ beforeEach(async () => {
   client = await pool.connect();
   await client.query('BEGIN');
   setTestClient(client);
+  vi.spyOn(openLibrary, 'checkBookExists').mockResolvedValue(false);
 });
 
 afterEach(async () => {
   await client.query('ROLLBACK');
   client.release();
   setTestClient(null);
+  vi.restoreAllMocks();
 });
 
 describe('books API', () => {

--- a/backend/tests/socket.test.ts
+++ b/backend/tests/socket.test.ts
@@ -5,8 +5,13 @@ import type {
   ServerToClientEvents,
   InterServerEvents,
   SocketData,
+  ChatMessage,
 } from '../src/socket.js';
-import Client from 'socket.io-client';
+import Client, {
+  type ManagerOptions,
+  type SocketOptions,
+} from 'socket.io-client';
+import type { AddressInfo } from 'net';
 import { beforeAll, afterAll, describe, expect, test, vi } from 'vitest';
 import app from '../src/app.js';
 import { setupWebsocket } from '../src/socket.js';
@@ -34,7 +39,8 @@ describe('websocket messaging', () => {
     >(httpServer);
     setupWebsocket(io);
     await new Promise<void>((resolve) => httpServer.listen(() => resolve()));
-    const port = (httpServer.address() as any).port;
+    const address = httpServer.address() as AddressInfo;
+    const port = address.port;
     vi.spyOn(userRepo, 'findUserById').mockResolvedValue({
       id: 1,
       name: 'Test',
@@ -47,9 +53,10 @@ describe('websocket messaging', () => {
     const token = jwt.sign({ id: 1 }, process.env.JWT_SECRET!, {
       algorithm: jwtAlgorithm,
     });
-    clientSocket = Client(`http://localhost:${port}`, {
-      extraHeaders: { cookie: `sessionToken=${token}` } as any,
-    } as any);
+    const options: Partial<ManagerOptions & SocketOptions> = {
+      extraHeaders: { cookie: `sessionToken=${token}` },
+    };
+    clientSocket = Client(`http://localhost:${port}`, options);
     await new Promise<void>((resolve) =>
       clientSocket.on('connect', () => resolve())
     );
@@ -63,12 +70,12 @@ describe('websocket messaging', () => {
 
   test('broadcasts messages without exposing sensitive data', () => {
     return new Promise<void>((resolve) => {
-      clientSocket.on('message', (msg: any) => {
+      clientSocket.on('message', (msg: ChatMessage) => {
         expect(msg.text).toBe('hello');
         expect(msg.user).toEqual({ id: 1, name: 'Test' });
         expect(msg.timestamp).toBeTruthy();
         expect(msg.channel).toBe('general');
-        expect((msg.user as any).email).toBeUndefined();
+        expect('email' in msg.user).toBe(false);
         resolve();
       });
       clientSocket.emit('message', { text: 'hello', channel: 'general' });

--- a/frontend/src/hooks/socket/useChatSocket.ts
+++ b/frontend/src/hooks/socket/useChatSocket.ts
@@ -21,7 +21,7 @@ export const useChatSocket = () => {
   useEffect(() => {
     const apiUrl =
       import.meta.env.PUBLIC_API_BASE_URL || 'http://localhost:4000'
-    // Ensure we connect to the server origin without any API prefix to avoid
+    // Ensure we connect to the server origin without an API prefix to avoid
     // Socket.IO "Invalid namespace" errors in production environments.
     const { origin } = new URL(apiUrl, window.location.origin)
     const s = io(origin, { withCredentials: true })

--- a/frontend/tests/utils/cookies.test.ts
+++ b/frontend/tests/utils/cookies.test.ts
@@ -16,11 +16,9 @@ describe('clearAllCookies', () => {
   })
 
   test('handles missing document gracefully', () => {
-    const original = global.document
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (global as any).document
+    const original = globalThis.document
+    delete (globalThis as { document?: Document }).document
     expect(() => clearAllCookies()).not.toThrow()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(global as any).document = original
+    ;(globalThis as { document?: Document }).document = original
   })
 })


### PR DESCRIPTION
## Summary
- extend books table with bibliographic fields and verification flag
- add OpenLibrary-powered search and verification API endpoints
- document and test book verification workflow
- encode book API errors with i18n keys and document backend guideline