### PR TITLE
docs: add database schema and backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,13 @@ Estas instrucciones aplican a todo el repositorio.
    npm run format:backend
    npm run format:frontend
    ```
-4. Verifica que el árbol de trabajo esté limpio con `git status --short`.
-5. Si algún comando falla, corrige los errores y vuelve a ejecutar.
+4. Actualiza el backlog de documentación antes de abrir la PR:
+   - Revisa `docs/backlog.md` y comprueba si ya existe una entrada para la funcionalidad.
+   - Si existe, marca la fila como `Hecho` y describe brevemente lo realizado.
+   - Si solo está parcialmente implementada, actualiza la descripción y crea una nueva fila para lo pendiente.
+   - Si no existe, agrega una nueva entrada manteniendo el estilo y evitando duplicados.
+5. Verifica que el árbol de trabajo esté limpio con `git status --short`.
+6. Si algún comando falla, corrige los errores y vuelve a ejecutar.
 
 ## Estilo y herramientas
 - Usa `rg` para buscar en el código en lugar de `grep` o `ls -R`.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,13 @@
+# Backlog
+
+| Estado    | Título | Descripción |
+|-----------|--------|-------------|
+| Hecho | Documentación inicial del esquema de base de datos | Se creó `docs/base_de_datos.md` con tablas, relaciones y proyecciones. |
+| Pendiente | Escalabilidad geográfica con PostGIS | Agrupar usuarios y rincones mediante `ST_ClusterKMeans` y consultas de cercanía. |
+| Pendiente | Migraciones secuenciales del esquema | Integrar herramienta de migraciones para controlar versiones. |
+| Pendiente | Tablas de auditoría y consentimientos | Registrar actividades y permisos para cumplir RGPD. |
+| Pendiente | Internacionalización de catálogos y textos | Añadir campos `locale` y tablas de traducciones. |
+| Pendiente | Búsqueda full-text con índices GIN | Optimizar búsquedas en libros y publicaciones. |
+| Pendiente | Tablas de eventos para métricas | Capturar visitas, likes y otras interacciones. |
+| Pendiente | Sistema de reportes y moderación | Gestionar contenido inapropiado con `reports` y `moderation_actions`. |
+| Pendiente | Sugerencias de libros por proximidad y gustos | Recomendar libros ofrecidos por usuarios cercanos. |

--- a/docs/base_de_datos.md
+++ b/docs/base_de_datos.md
@@ -1,0 +1,159 @@
+# Esquema de base de datos
+
+## Tablas principales
+
+### `users`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` (PK) | SERIAL | Identificador del usuario |
+| `name` | TEXT | Nombre público |
+| `email` | TEXT UNIQUE | Correo de autenticación |
+| `password_hash` | TEXT | Hash de la contraseña |
+| `role` | TEXT | Perfil del usuario (`user`, `admin`, etc.) |
+| `language` | TEXT | Idioma preferido |
+| `bio` | TEXT | Información de perfil |
+| `location` | GEOGRAPHY(Point,4326) | Coordenadas del usuario |
+| `search_radius` | INTEGER | Radio de búsqueda en metros |
+| `created_at` | TIMESTAMPTZ | Fecha de creación |
+| `updated_at` | TIMESTAMPTZ | Última actualización |
+
+### `books`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` (PK) | SERIAL | Identificador interno |
+| `title` | TEXT | Título del libro |
+| `isbn` | TEXT | Código ISBN |
+| `authors` | TEXT | Autores principales |
+| `publisher` | TEXT | Editorial |
+| `published_year` | INTEGER | Año de publicación |
+| `description` | TEXT | Descripción o sinopsis |
+| `verified` | BOOLEAN | Indica si la ficha fue validada |
+| `created_at` | TIMESTAMPTZ | Fecha de registro |
+
+### `book_images`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` (PK) | SERIAL | Identificador |
+| `book_id` (FK→`books.id`) | INTEGER | Libro asociado |
+| `url` | TEXT | Ruta a la imagen |
+| `is_primary` | BOOLEAN | Marca la imagen principal |
+| `metadata` | JSONB | Información adicional |
+| `created_at` | TIMESTAMPTZ | Fecha de carga |
+
+### `publications`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` (PK) | SERIAL | Identificador |
+| `user_id` (FK→`users.id`) | INTEGER | Autor de la publicación |
+| `book_id` (FK→`books.id`) | INTEGER | Libro referenciado |
+| `status` | ENUM('draft','pending','verified','rejected') | Estado de la publicación |
+| `type` | ENUM('offer','request','exchange') | Tipo de interacción |
+| `description` | TEXT | Detalle del ejemplar |
+| `condition` | TEXT | Estado físico |
+| `location` | GEOGRAPHY(Point,4326) | Ubicación opcional del intercambio |
+| `created_at` | TIMESTAMPTZ | Fecha de creación |
+| `updated_at` | TIMESTAMPTZ | Última actualización |
+| `verified_at` | TIMESTAMPTZ | Fecha de verificación |
+| `verified_by` (FK→`users.id`) | INTEGER | Usuario verificador |
+
+### `publication_stats`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `publication_id` (PK/FK→`publications.id`) | INTEGER | Publicación asociada |
+| `views` | INTEGER | Cantidad de vistas |
+| `likes` | INTEGER | Reacciones positivas |
+| `messages_count` | INTEGER | Mensajes recibidos |
+| `swaps_completed` | INTEGER | Intercambios concretados |
+| `updated_at` | TIMESTAMPTZ | Última actualización |
+
+### `publication_images`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` (PK) | SERIAL | Identificador |
+| `publication_id` (FK→`publications.id`) | INTEGER | Publicación asociada |
+| `url` | TEXT | Ruta a la imagen |
+| `is_primary` | BOOLEAN | Marca la imagen principal |
+| `metadata` | JSONB | Información adicional |
+| `created_at` | TIMESTAMPTZ | Fecha de carga |
+
+### `conversations`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` (PK) | SERIAL | Identificador |
+| `publication_id` (FK→`publications.id`, opcional) | INTEGER | Publicación sobre la que se conversa |
+| `created_at` | TIMESTAMPTZ | Fecha de inicio |
+| `status` | ENUM('open','closed','archived') | Estado de la conversación |
+| `last_message_at` | TIMESTAMPTZ | Último mensaje |
+
+### `messages`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` (PK) | SERIAL | Identificador |
+| `conversation_id` (FK→`conversations.id`) | INTEGER | Conversación asociada |
+| `sender_id` (FK→`users.id`) | INTEGER | Usuario remitente |
+| `recipient_id` (FK→`users.id`) | INTEGER | Usuario destinatario |
+| `content` | TEXT | Mensaje enviado |
+| `created_at` | TIMESTAMPTZ | Fecha de envío |
+| `read_at` | TIMESTAMPTZ | Fecha de lectura |
+
+### `book_corners`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` (PK) | SERIAL | Identificador |
+| `name` | TEXT | Nombre del Rincón |
+| `owner_user_id` (FK→`users.id`) | INTEGER | Propietario |
+| `location` | GEOGRAPHY(Point,4326) | Ubicación del Rincón |
+| `description` | TEXT | Información adicional |
+| `created_at` | TIMESTAMPTZ | Fecha de registro |
+
+### `genres`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` (PK) | SERIAL | Identificador |
+| `name` | TEXT | Nombre del género |
+
+### `user_genres`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `user_id` (FK→`users.id`) | INTEGER | Usuario |
+| `genre_id` (FK→`genres.id`) | INTEGER | Género asociado |
+
+### `book_suggestions`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` (PK) | SERIAL | Identificador |
+| `user_id` (FK→`users.id`) | INTEGER | Quien sugiere |
+| `title` | TEXT | Título del libro sugerido |
+| `authors` | TEXT | Autores |
+| `isbn` | TEXT | Código ISBN |
+| `status` | ENUM('pending','approved','rejected') | Estado de la sugerencia |
+| `created_at` | TIMESTAMPTZ | Fecha de registro |
+
+### Tablas auxiliares futuras
+- `notifications`
+- `swaps`
+- `follows` / `favorites`
+- `audit_logs`
+
+## Relaciones principales
+- Usuarios ↔ Publicaciones: 1‑N
+- Publicaciones ↔ Libros: N‑1
+- Publicaciones ↔ Estadísticas: 1‑1
+- Publicaciones ↔ Imágenes de publicación: 1‑N
+- Publicaciones ↔ Conversaciones: 1‑N (opcional)
+- Conversaciones ↔ Mensajes: 1‑N
+- Usuarios ↔ Mensajes: N‑N a través de `conversations`
+- Libros ↔ Imágenes de libro: 1‑N
+- Usuarios ↔ Rincones de libros: 1‑N
+- Usuarios ↔ Géneros: N‑N
+- Sugerencias ↔ Usuarios: N‑1
+
+## Proyección a futuro
+- Escalabilidad geográfica con `ST_ClusterKMeans` y consultas de proximidad
+- Migraciones secuenciales para control de versiones
+- Tablas de auditoría y consentimientos (RGPD)
+- Internacionalización de textos y catálogos
+- Búsqueda *full‑text* con índices GIN y `tsvector`
+- Tablas de eventos para análisis y métricas
+- Sistema de reportes y acciones de moderación
+- Sugerencias de libros basadas en cercanía y gustos


### PR DESCRIPTION
## Summary
- document full database schema and relationships
- add project backlog with implemented and pending tasks
- require backlog updates via AGENTS instructions