### PR TITLE
Add reusable chat bubble wrapper for messages

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -116,6 +116,7 @@ Feature 5.1 Mensajería 1:1
 
 - [~] S-5.1 Chat 1:1 con plantillas de primer contacto (Must, E1; BR-40)
   - Éxito: iniciar conversación desde ficha en ≤2 taps/clicks.
+  - Actualización 2025-01-09: se creó el wrapper `BubbleBase` y se adaptaron los mensajes genéricos para reutilizarlo sin alterar el estilo actual, preparando el chat para nuevas variantes de burbuja.
 - [ ] S-5.2 Bloqueo/Reporte en conversación y ficha (Must, E1; BR-43)
   - Éxito: acción en ≤2 pasos.
 

--- a/frontend/src/components/messages/Messages.mock.ts
+++ b/frontend/src/components/messages/Messages.mock.ts
@@ -22,25 +22,25 @@ export const mockConversations: Conversation[] = [
     messages: [
       {
         id: 1,
-        sender: 'them',
+        role: 'them',
         text: "I'll trade it for your book",
         time: '4:30 PM',
       },
       {
         id: 2,
-        sender: 'me',
+        role: 'me',
         text: "Hi! I'm interested in To Kill a Mockingbird",
         time: '4:32 PM',
       },
       {
         id: 3,
-        sender: 'them',
+        role: 'them',
         text: 'Sure! Are you offering a book for exchange?',
         time: '4:35 PM',
       },
       {
         id: 4,
-        sender: 'me',
+        role: 'me',
         text: "I'll trade it for your book",
         book: {
           title: 'The Wind-Up Bird Chronicle',
@@ -51,7 +51,7 @@ export const mockConversations: Conversation[] = [
       },
       {
         id: 5,
-        sender: 'them',
+        role: 'them',
         text: 'Sounds good!',
         time: '4:37 PM',
       },
@@ -69,7 +69,7 @@ export const mockConversations: Conversation[] = [
     messages: [
       {
         id: 1,
-        sender: 'them',
+        role: 'them',
         text: 'Great, thanks!',
         time: '1:15 PM',
       },
@@ -87,7 +87,7 @@ export const mockConversations: Conversation[] = [
     messages: [
       {
         id: 1,
-        sender: 'them',
+        role: 'them',
         text: 'Swap request pending',
         time: 'Yesterday',
       },
@@ -105,7 +105,7 @@ export const mockConversations: Conversation[] = [
     messages: [
       {
         id: 1,
-        sender: 'them',
+        role: 'them',
         text: 'Whoa, sounds like a great book!',
         time: 'Yesterday',
       },

--- a/frontend/src/components/messages/Messages.module.scss
+++ b/frontend/src/components/messages/Messages.module.scss
@@ -198,61 +198,6 @@
   }
 }
 
-.message {
-  max-width: 70%;
-  padding: $spacing-1 $spacing-2;
-  border-radius: 20px;
-  background: var(--background-card);
-  box-shadow: 0 2px 8px rgb(0 0 0 / 6%);
-  align-self: flex-start;
-  font-size: 15px;
-  line-height: 1.45;
-}
-
-.me {
-  align-self: flex-end;
-  background: rgb(var(--primary-rgb));
-  color: #fff;
-}
-
-.bookCard {
-  display: flex;
-  gap: $spacing-2;
-  margin-top: $spacing-1;
-  padding: $spacing-1;
-  border-radius: 10px;
-  background: inherit;
-  box-shadow: inset 0 0 0 1px var(--color-primary-200);
-}
-
-.bookCard img {
-  width: 48px;
-  height: 68px;
-  object-fit: cover;
-  border-radius: 6px;
-}
-
-.bookTitle {
-  font-weight: 600;
-}
-
-.bookAuthor {
-  opacity: 0.8;
-  font-size: $small-font-size;
-}
-
-.time {
-  display: block;
-  font-size: 11px;
-  opacity: 0.65;
-  margin-top: $spacing-1;
-  text-align: right;
-}
-
-.message:not(.me) .time {
-  text-align: left;
-}
-
 .inputArea {
   display: flex;
   align-items: center;

--- a/frontend/src/components/messages/Messages.tsx
+++ b/frontend/src/components/messages/Messages.tsx
@@ -29,7 +29,7 @@ export const Messages = () => {
       .filter((m) => m.channel === selected.user.name)
       .map((m, idx) => ({
         id: idx,
-        sender: m.user.id === currentUser?.id ? 'me' : 'them',
+        role: m.user.id === currentUser?.id ? 'me' : 'them',
         tone: m.user.id === currentUser?.id ? 'primary' : 'neutral',
         text: m.text,
         time: new Date(m.timestamp).toLocaleTimeString([], {
@@ -132,7 +132,7 @@ export const Messages = () => {
               {mappedMessages.map((msg) => (
                 <BubbleText
                   key={msg.id}
-                  role={msg.sender}
+                  role={msg.role}
                   tone={msg.tone}
                   text={msg.text}
                   book={msg.book}

--- a/frontend/src/components/messages/Messages.tsx
+++ b/frontend/src/components/messages/Messages.tsx
@@ -7,6 +7,7 @@ import { ReactComponent as AttachIcon } from '@src/assets/icons/attachments.svg'
 import { ReactComponent as EmojiIcon } from '@src/assets/icons/emoji.svg'
 import { ReactComponent as InfoIcon } from '@src/assets/icons/info.svg'
 
+import { BubbleText } from './components/BubbleText/BubbleText'
 import styles from './Messages.module.scss'
 import { Conversation, Message } from './Messages.types'
 
@@ -29,6 +30,7 @@ export const Messages = () => {
       .map((m, idx) => ({
         id: idx,
         sender: m.user.id === currentUser?.id ? 'me' : 'them',
+        tone: m.user.id === currentUser?.id ? 'primary' : 'neutral',
         text: m.text,
         time: new Date(m.timestamp).toLocaleTimeString([], {
           hour: '2-digit',
@@ -128,27 +130,14 @@ export const Messages = () => {
             </header>
             <div className={styles.messages}>
               {mappedMessages.map((msg) => (
-                <div
+                <BubbleText
                   key={msg.id}
-                  className={`${styles.message} ${msg.sender === 'me' ? styles.me : ''}`}
-                >
-                  {msg.text && <p>{msg.text}</p>}
-                  {msg.book && (
-                    <div className={styles.bookCard}>
-                      <img
-                        src={msg.book.cover}
-                        alt={`Cover of ${msg.book.title}`}
-                      />
-                      <div>
-                        <div className={styles.bookTitle}>{msg.book.title}</div>
-                        <div className={styles.bookAuthor}>
-                          {msg.book.author}
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                  <span className={styles.time}>{msg.time}</span>
-                </div>
+                  role={msg.sender}
+                  tone={msg.tone}
+                  text={msg.text}
+                  book={msg.book}
+                  time={msg.time}
+                />
               ))}
             </div>
             <div className={styles.inputArea}>

--- a/frontend/src/components/messages/Messages.types.ts
+++ b/frontend/src/components/messages/Messages.types.ts
@@ -4,12 +4,23 @@ export type Book = {
   cover: string
 }
 
+export type MessageRole = 'me' | 'them' | 'system'
+
+export type MessageTone =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'neutral'
+
 export type Message = {
   id: number
-  sender: 'me' | 'them'
+  sender: MessageRole
   text?: string
   book?: Book
   time: string
+  tone?: MessageTone
 }
 
 export type Conversation = {

--- a/frontend/src/components/messages/Messages.types.ts
+++ b/frontend/src/components/messages/Messages.types.ts
@@ -16,7 +16,7 @@ export type MessageTone =
 
 export type Message = {
   id: number
-  sender: MessageRole
+  role: MessageRole
   text?: string
   book?: Book
   time: string

--- a/frontend/src/components/messages/components/BubbleBase/BubbleBase.module.scss
+++ b/frontend/src/components/messages/components/BubbleBase/BubbleBase.module.scss
@@ -10,7 +10,6 @@
   line-height: 1.45;
   display: flex;
   flex-direction: column;
-  gap: $spacing-1;
   align-self: flex-start;
   color: var(--text-primary);
   transition:

--- a/frontend/src/components/messages/components/BubbleBase/BubbleBase.module.scss
+++ b/frontend/src/components/messages/components/BubbleBase/BubbleBase.module.scss
@@ -1,0 +1,135 @@
+@import '@styles/variables';
+
+.bubble {
+  max-width: 70%;
+  padding: $spacing-1 $spacing-2;
+  border-radius: 20px;
+  background: var(--background-card);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 6%);
+  font-size: 15px;
+  line-height: 1.45;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+  align-self: flex-start;
+  color: var(--text-primary);
+  transition:
+    background $transition-duration-fast $transition-timing-function,
+    color $transition-duration-fast $transition-timing-function;
+}
+
+.role-me {
+  align-self: flex-end;
+}
+
+.role-them {
+  align-self: flex-start;
+}
+
+.role-system {
+  align-self: center;
+  max-width: 80%;
+  text-align: center;
+}
+
+.header {
+  font-weight: $font-weight-medium;
+  font-size: $small-font-size;
+  color: var(--text-secondary);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-1;
+  color: inherit;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-1;
+  justify-content: flex-end;
+}
+
+.meta {
+  width: 100%;
+  font-size: 11px;
+  opacity: 0.65;
+  margin-top: $spacing-1;
+  text-align: right;
+}
+
+.role-them .meta {
+  text-align: left;
+}
+
+.role-system .meta {
+  text-align: center;
+}
+
+.tone-neutral {
+  background: var(--background-card);
+  color: var(--text-primary);
+}
+
+.tone-primary {
+  background: rgb(var(--primary-rgb));
+  color: #fff;
+}
+
+.tone-primary .header,
+.tone-primary .meta,
+.tone-primary .actions {
+  color: color-mix(in srgb, #fff 80%, transparent);
+}
+
+.tone-secondary {
+  background: color-mix(
+    in srgb,
+    var(--background-card) 80%,
+    var(--text-secondary) 20%
+  );
+  color: var(--text-primary);
+}
+
+.tone-success {
+  background: color-mix(
+    in srgb,
+    var(--background-card) 70%,
+    var(--color-success) 30%
+  );
+  color: var(--text-primary);
+}
+
+.tone-warning {
+  background: color-mix(
+    in srgb,
+    var(--background-card) 65%,
+    var(--color-warning) 35%
+  );
+  color: var(--text-primary);
+}
+
+.tone-info {
+  background: color-mix(
+    in srgb,
+    var(--background-card) 70%,
+    var(--color-info) 30%
+  );
+  color: var(--text-primary);
+}
+
+.role-me.tone-neutral {
+  background: var(--background-card);
+}
+
+@media (max-width: $breakpoint-tablet) {
+  .bubble {
+    max-width: 85%;
+  }
+
+  .role-system {
+    max-width: 95%;
+  }
+}

--- a/frontend/src/components/messages/components/BubbleBase/BubbleBase.tsx
+++ b/frontend/src/components/messages/components/BubbleBase/BubbleBase.tsx
@@ -1,0 +1,52 @@
+import { ReactNode } from 'react'
+
+import type { MessageRole, MessageTone } from '../../Messages.types'
+
+import styles from './BubbleBase.module.scss'
+
+export type BubbleRole = MessageRole
+export type BubbleTone = MessageTone
+
+export type BubbleBaseProps = {
+  role?: BubbleRole
+  tone?: BubbleTone
+  header?: ReactNode
+  children: ReactNode
+  actions?: ReactNode
+  meta?: ReactNode
+  className?: string
+  bodyClassName?: string
+  ariaLabel?: string
+}
+
+export const BubbleBase = ({
+  role = 'them',
+  tone = 'neutral',
+  header,
+  children,
+  actions,
+  meta,
+  className,
+  bodyClassName,
+  ariaLabel,
+}: BubbleBaseProps) => {
+  const bubbleClassName = [
+    styles.bubble,
+    styles[`role-${role}`],
+    styles[`tone-${tone}`],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const bodyClassNames = [styles.body, bodyClassName].filter(Boolean).join(' ')
+
+  return (
+    <article className={bubbleClassName} role="group" aria-label={ariaLabel}>
+      {header ? <header className={styles.header}>{header}</header> : null}
+      <div className={bodyClassNames}>{children}</div>
+      {actions ? <div className={styles.actions}>{actions}</div> : null}
+      {meta ? <div className={styles.meta}>{meta}</div> : null}
+    </article>
+  )
+}

--- a/frontend/src/components/messages/components/BubbleText/BubbleText.module.scss
+++ b/frontend/src/components/messages/components/BubbleText/BubbleText.module.scss
@@ -1,0 +1,45 @@
+@import '@styles/variables';
+
+.text {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.bookCard {
+  display: flex;
+  gap: $spacing-2;
+  margin-top: $spacing-1;
+  padding: $spacing-1;
+  border-radius: 10px;
+  background: inherit;
+  box-shadow: inset 0 0 0 1px var(--color-primary-200);
+  align-items: center;
+}
+
+.bookCover {
+  width: 48px;
+  height: 68px;
+  object-fit: cover;
+  border-radius: 6px;
+}
+
+.bookInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.bookTitle {
+  font-weight: 600;
+}
+
+.bookAuthor {
+  font-size: $small-font-size;
+  opacity: 0.8;
+}
+
+.time {
+  display: block;
+  width: 100%;
+  text-align: inherit;
+}

--- a/frontend/src/components/messages/components/BubbleText/BubbleText.tsx
+++ b/frontend/src/components/messages/components/BubbleText/BubbleText.tsx
@@ -38,7 +38,7 @@ export const BubbleText = ({
       <div className={styles.bookCard}>
         <img
           src={book.cover}
-          alt={book.title}
+          alt={`Cover of ${book.title}`}
           className={styles.bookCover}
           loading="lazy"
         />

--- a/frontend/src/components/messages/components/BubbleText/BubbleText.tsx
+++ b/frontend/src/components/messages/components/BubbleText/BubbleText.tsx
@@ -1,0 +1,52 @@
+import { Book } from '../../Messages.types'
+import {
+  BubbleBase,
+  BubbleBaseProps,
+  BubbleRole,
+  BubbleTone,
+} from '../BubbleBase/BubbleBase'
+
+import styles from './BubbleText.module.scss'
+
+export type BubbleTextProps = {
+  role?: BubbleRole
+  tone?: BubbleTone
+  text?: string
+  book?: Book
+  time?: string
+  className?: string
+} & Pick<BubbleBaseProps, 'ariaLabel'>
+
+export const BubbleText = ({
+  role = 'them',
+  tone = 'neutral',
+  text,
+  book,
+  time,
+  className,
+  ariaLabel,
+}: BubbleTextProps) => (
+  <BubbleBase
+    role={role}
+    tone={tone}
+    ariaLabel={ariaLabel}
+    className={className}
+    meta={time ? <span className={styles.time}>{time}</span> : null}
+  >
+    {text ? <p className={styles.text}>{text}</p> : null}
+    {book ? (
+      <div className={styles.bookCard}>
+        <img
+          src={book.cover}
+          alt={book.title}
+          className={styles.bookCover}
+          loading="lazy"
+        />
+        <div className={styles.bookInfo}>
+          <span className={styles.bookTitle}>{book.title}</span>
+          <span className={styles.bookAuthor}>{book.author}</span>
+        </div>
+      </div>
+    ) : null}
+  </BubbleBase>
+)


### PR DESCRIPTION
## Summary
- introduce a BubbleBase wrapper that centralises shared chat bubble structure, alignment and tone styling
- add a BubbleText component and render it from Messages so text and book payloads keep the existing appearance while using the wrapper
- extend message typings and backlog documentation to account for the new bubble layer

## Testing
- npm run format:backend
- npm run format:frontend
- npm run test:frontend
- npm run test:backend