### PR TITLE
Update messages mocks to Spanish and fix layout

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -117,6 +117,7 @@ Feature 5.1 Mensajería 1:1
 - [~] S-5.1 Chat 1:1 con plantillas de primer contacto (Must, E1; BR-40)
   - Éxito: iniciar conversación desde ficha en ≤2 taps/clicks.
   - Actualización 2025-01-09: se creó el wrapper `BubbleBase` y se adaptaron los mensajes genéricos para reutilizarlo sin alterar el estilo actual, preparando el chat para nuevas variantes de burbuja.
+  - Actualización 2025-09-29: se ajustaron los mocks del chat al español y se corrigió el layout para que la barra de mensajes permanezca visible mientras el historial hace scroll.
 - [ ] S-5.2 Bloqueo/Reporte en conversación y ficha (Must, E1; BR-43)
   - Éxito: acción en ≤2 pasos.
 

--- a/frontend/src/components/messages/Messages.mock.ts
+++ b/frontend/src/components/messages/Messages.mock.ts
@@ -23,27 +23,27 @@ export const mockConversations: Conversation[] = [
       {
         id: 1,
         role: 'them',
-        text: "I'll trade it for your book",
+        text: 'Puedo cambiarlo por tu libro',
         time: '4:30 PM',
       },
       {
         id: 2,
         role: 'me',
-        text: "Hi! I'm interested in To Kill a Mockingbird",
+        text: '¡Hola! Estoy interesado en Matar a un ruiseñor',
         time: '4:32 PM',
       },
       {
         id: 3,
         role: 'them',
-        text: 'Sure! Are you offering a book for exchange?',
+        text: '¡Claro! ¿Ofreces algún libro para el intercambio?',
         time: '4:35 PM',
       },
       {
         id: 4,
         role: 'me',
-        text: "I'll trade it for your book",
+        text: 'Puedo cambiarlo por tu libro',
         book: {
-          title: 'The Wind-Up Bird Chronicle',
+          title: 'Crónica del pájaro que da cuerda al mundo',
           author: 'Haruki Murakami',
           cover: 'https://covers.openlibrary.org/b/id/240726-S.jpg',
         },
@@ -52,7 +52,7 @@ export const mockConversations: Conversation[] = [
       {
         id: 5,
         role: 'them',
-        text: 'Sounds good!',
+        text: '¡Perfecto!',
         time: '4:37 PM',
       },
       {
@@ -97,7 +97,7 @@ export const mockConversations: Conversation[] = [
       {
         id: 1,
         role: 'them',
-        text: 'Great, thanks!',
+        text: '¡Genial, gracias!',
         time: '1:15 PM',
       },
     ],
@@ -115,7 +115,7 @@ export const mockConversations: Conversation[] = [
       {
         id: 1,
         role: 'them',
-        text: 'Swap request pending',
+        text: 'Solicitud de intercambio pendiente',
         time: 'Yesterday',
       },
     ],
@@ -133,7 +133,7 @@ export const mockConversations: Conversation[] = [
       {
         id: 1,
         role: 'them',
-        text: 'Whoa, sounds like a great book!',
+        text: '¡Guau, suena como un gran libro!',
         time: 'Yesterday',
       },
     ],

--- a/frontend/src/components/messages/Messages.module.scss
+++ b/frontend/src/components/messages/Messages.module.scss
@@ -12,6 +12,7 @@
 .content {
   flex: 1;
   display: flex;
+  min-height: 0;
 }
 
 .sidebar {
@@ -41,6 +42,7 @@
   margin: rem(10px);
   padding: 0;
   overflow-y: auto;
+  min-height: 0;
   -ms-overflow-style: none;
   scrollbar-width: none;
 
@@ -123,6 +125,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .chatHeader {
@@ -190,6 +193,7 @@
   flex-direction: column;
   gap: $spacing-1;
   overflow-y: auto;
+  min-height: 0;
   -ms-overflow-style: none;
   scrollbar-width: none;
 

--- a/frontend/src/components/messages/Messages.tsx
+++ b/frontend/src/components/messages/Messages.tsx
@@ -29,6 +29,10 @@ export const Messages = () => {
     if (!selected) return []
 
     const staticMessages: Message[] = selected.messages ?? []
+    const maxStaticId = staticMessages.reduce(
+      (maxId, message) => Math.max(maxId, message.id),
+      0
+    )
     const liveMessages = messages
       .filter((m) => m.channel === selected.user.name)
       .map((m, idx) => {
@@ -36,7 +40,7 @@ export const Messages = () => {
         const tone: Message['tone'] = role === 'me' ? 'primary' : 'neutral'
 
         return {
-          id: staticMessages.length + idx,
+          id: maxStaticId + idx + 1,
           role,
           tone,
           text: m.text,
@@ -61,7 +65,14 @@ export const Messages = () => {
     <div className={styles.wrapper}>
       {!isConnected && (
         <div className={styles.offlineBanner} role="alert">
-          {error ? `Disconnected: ${error}` : 'Disconnected'}
+          {error
+            ? t('community.messages.status.disconnectedError', {
+                defaultValue: `Desconectado: ${error}`,
+                error,
+              })
+            : t('community.messages.status.disconnected', {
+                defaultValue: 'Desconectado',
+              })}
         </div>
       )}
       <div className={styles.content}>
@@ -70,8 +81,12 @@ export const Messages = () => {
             <h2>{t('community.messages.title')}</h2>
             <input
               className={styles.search}
-              placeholder="Search"
-              aria-label="Search conversations"
+              placeholder={t('community.messages.searchPlaceholder', {
+                defaultValue: 'Buscar',
+              })}
+              aria-label={t('community.messages.searchAriaLabel', {
+                defaultValue: 'Buscar conversaciones',
+              })}
             />
           </div>
           <ul className={styles.conversationList}>
@@ -100,9 +115,11 @@ export const Messages = () => {
                           'community.messages.agreement.confirmation.title'
                         )
                       }
-                      if ('text' in lastMsg && lastMsg.text) return lastMsg.text
                       if ('book' in lastMsg && lastMsg.book)
-                        return t('community.messages.snippets.sharedBook')
+                        return t('community.messages.snippets.sharedBook', {
+                          defaultValue: 'Compartió un libro',
+                        })
+                      if ('text' in lastMsg && lastMsg.text) return lastMsg.text
                       return ''
                     })()}
                   </span>
@@ -110,17 +127,23 @@ export const Messages = () => {
                 <div className={styles.badges}>
                   {conv.badges.includes('unread') && (
                     <span className={`${styles.badge} ${styles.badgeUnread}`}>
-                      Unread
+                      {t('community.messages.badges.unread', {
+                        defaultValue: 'Sin leer',
+                      })}
                     </span>
                   )}
                   {conv.badges.includes('book') && (
                     <span className={`${styles.badge} ${styles.badgeBook}`}>
-                      Book
+                      {t('community.messages.badges.book', {
+                        defaultValue: 'Libro',
+                      })}
                     </span>
                   )}
                   {conv.badges.includes('swap') && (
                     <span className={`${styles.badge} ${styles.badgeSwap}`}>
-                      Swap Offer
+                      {t('community.messages.badges.swap', {
+                        defaultValue: 'Oferta de intercambio',
+                      })}
                     </span>
                   )}
                 </div>
@@ -140,12 +163,25 @@ export const Messages = () => {
                 <span className={styles.name}>{selected.user.name}</span>
                 <span className={styles.status}>
                   {selected.user.online
-                    ? 'Online'
-                    : `Last seen ${selected.user.lastSeen}`}
+                    ? t('community.messages.status.online', {
+                        defaultValue: 'En línea',
+                      })
+                    : t('community.messages.status.lastSeen', {
+                        defaultValue: 'Última vez {{lastSeen}}',
+                        lastSeen:
+                          selected.user.lastSeen ??
+                          t('community.messages.status.lastSeenFallback', {
+                            defaultValue: 'hace un momento',
+                          }),
+                      })}
                 </span>
               </div>
               <div className={styles.actions}>
-                <button aria-label="Profile info">
+                <button
+                  aria-label={t('community.messages.actions.profile', {
+                    defaultValue: 'Ver información del perfil',
+                  })}
+                >
                   <InfoIcon />
                 </button>
               </div>
@@ -192,20 +228,32 @@ export const Messages = () => {
                 <input
                   value={text}
                   onChange={(e) => setText(e.target.value)}
-                  placeholder="Message..."
+                  placeholder={t('community.messages.inputPlaceholder', {
+                    defaultValue: 'Escribe un mensaje...',
+                  })}
                   disabled={!isConnected}
                 />
                 <div className={styles.inputIcons}>
-                  <button aria-label="Attachments">
+                  <button
+                    aria-label={t('community.messages.actions.attachments', {
+                      defaultValue: 'Adjuntar archivos',
+                    })}
+                  >
                     <AttachIcon />
                   </button>
-                  <button aria-label="Emoji">
+                  <button
+                    aria-label={t('community.messages.actions.emoji', {
+                      defaultValue: 'Abrir selector de emojis',
+                    })}
+                  >
                     <EmojiIcon />
                   </button>
                 </div>
               </div>
               <button
-                aria-label="Send"
+                aria-label={t('community.messages.actions.send', {
+                  defaultValue: 'Enviar mensaje',
+                })}
                 onClick={handleSend}
                 className={styles.sendButton}
                 disabled={!isConnected}
@@ -216,7 +264,9 @@ export const Messages = () => {
           </div>
         ) : (
           <div className={styles.placeholder}>
-            Select a conversation to start
+            {t('community.messages.placeholder', {
+              defaultValue: 'Selecciona una conversación para comenzar',
+            })}
           </div>
         )}
       </div>

--- a/frontend/tests/components/messages/Messages.test.tsx
+++ b/frontend/tests/components/messages/Messages.test.tsx
@@ -18,7 +18,7 @@ describe('Messages component', () => {
     const { getByText, getByPlaceholderText } = renderWithProviders(
       <Messages />
     )
-    expect(getByText(/disconnected/i)).toBeInTheDocument()
-    expect(getByPlaceholderText('Message...')).toBeDisabled()
+    expect(getByText(/desconectado/i)).toBeInTheDocument()
+    expect(getByPlaceholderText('Escribe un mensaje...')).toBeDisabled()
   })
 })

--- a/frontend/tests/pages/messages/MessagesPage.test.tsx
+++ b/frontend/tests/pages/messages/MessagesPage.test.tsx
@@ -7,6 +7,6 @@ import { renderWithProviders } from '../../test-utils'
 describe('MessagesPage', () => {
   test('renders message input', () => {
     const { getByPlaceholderText } = renderWithProviders(<MessagesPage />)
-    expect(getByPlaceholderText('Message...')).toBeInTheDocument()
+    expect(getByPlaceholderText('Escribe un mensaje...')).toBeInTheDocument()
   })
 })

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -26,7 +26,20 @@ vi.mock('react-i18next', async () => {
   return {
     ...actual,
     useTranslation: () => ({
-      t: (key: string) => key, // Devuelve la key directamente
+      t: (key: string, options?: Record<string, unknown>) => {
+        const template =
+          (typeof options?.defaultValue === 'string'
+            ? options.defaultValue
+            : undefined) ?? key
+
+        if (!options) return template
+
+        return template.replace(/{{(.*?)}}/g, (_, varName: string) => {
+          const trimmed = varName.trim()
+          const value = options[trimmed]
+          return value !== undefined ? String(value) : ''
+        })
+      },
       i18n: { changeLanguage: () => Promise.resolve() },
     }),
     Trans: ({ children }: { children: React.ReactNode }) => children,


### PR DESCRIPTION
## Summary
- translate the mocked conversation copy to Spanish, add localized defaults for the chat UI, and improve i18n fallbacks in tests
- ensure live chat messages keep unique identifiers and keep the message composer visible by adjusting the layout flex constraints
- update the messaging backlog entry and align component tests with the new Spanish placeholders

## Testing
- npm run test:backend *(fails: database connection refused in CI environment)*
- npm run test:frontend
- npm run format:backend
- npm run format:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d94ab6329c832e809063d4ba04f102