### PR TITLE
Add frontend language preference tests

### DIFF
--- a/backend/tests/middleware/auth.test.ts
+++ b/backend/tests/middleware/auth.test.ts
@@ -1,16 +1,23 @@
-import type { Response, NextFunction } from 'express';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import jwt from 'jsonwebtoken';
+// prettier-ignore
+import type { Response, NextFunction } from 'express'
+// prettier-ignore
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+// prettier-ignore
+import jwt from 'jsonwebtoken'
+// prettier-ignore
 import {
   authenticate,
   type AuthenticatedRequest,
-} from '../../src/middleware/auth.js';
-import * as userRepository from '../../src/repositories/userRepository.js';
+} from '../../src/middleware/auth.js'
+// prettier-ignore
+import * as userRepository from '../../src/repositories/userRepository.js'
+// prettier-ignore
 import type {
   PublicUser,
   User,
-} from '../../src/repositories/userRepository.js';
-import { logger } from '../../src/utils/logger.js';
+} from '../../src/repositories/userRepository.js'
+// prettier-ignore
+import { logger } from '../../src/utils/logger.js'
 
 describe('authenticate middleware', () => {
   const originalJwtSecret = process.env.JWT_SECRET;

--- a/backend/tests/middleware/auth.test.ts
+++ b/backend/tests/middleware/auth.test.ts
@@ -1,23 +1,16 @@
-// prettier-ignore
-import type { Response, NextFunction } from 'express'
-// prettier-ignore
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-// prettier-ignore
-import jwt from 'jsonwebtoken'
-// prettier-ignore
+import type { Response, NextFunction } from 'express';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import jwt from 'jsonwebtoken';
 import {
   authenticate,
   type AuthenticatedRequest,
-} from '../../src/middleware/auth.js'
-// prettier-ignore
-import * as userRepository from '../../src/repositories/userRepository.js'
-// prettier-ignore
+} from '../../src/middleware/auth.js';
+import * as userRepository from '../../src/repositories/userRepository.js';
 import type {
   PublicUser,
   User,
-} from '../../src/repositories/userRepository.js'
-// prettier-ignore
-import { logger } from '../../src/utils/logger.js'
+} from '../../src/repositories/userRepository.js';
+import { logger } from '../../src/utils/logger.js';
 
 describe('authenticate middleware', () => {
   const originalJwtSecret = process.env.JWT_SECRET;

--- a/backend/tests/middleware/auth.test.ts
+++ b/backend/tests/middleware/auth.test.ts
@@ -1,0 +1,172 @@
+import type { Response, NextFunction } from 'express';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import jwt from 'jsonwebtoken';
+import {
+  authenticate,
+  type AuthenticatedRequest,
+} from '../../src/middleware/auth.js';
+import * as userRepository from '../../src/repositories/userRepository.js';
+import type {
+  PublicUser,
+  User,
+} from '../../src/repositories/userRepository.js';
+import { logger } from '../../src/utils/logger.js';
+
+describe('authenticate middleware', () => {
+  const originalJwtSecret = process.env.JWT_SECRET;
+  const originalJwtAlgorithm = process.env.JWT_ALGORITHM;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.JWT_SECRET = 'secret';
+    delete process.env.JWT_ALGORITHM;
+  });
+
+  afterEach(() => {
+    if (originalJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalJwtSecret;
+    }
+    if (originalJwtAlgorithm === undefined) {
+      delete process.env.JWT_ALGORITHM;
+    } else {
+      process.env.JWT_ALGORITHM = originalJwtAlgorithm;
+    }
+  });
+
+  function createResponseMock() {
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response;
+    return res;
+  }
+
+  function createNextMock() {
+    return vi.fn<Parameters<NextFunction>, void>();
+  }
+
+  test('returns 500 when JWT secret is not configured', async () => {
+    delete process.env.JWT_SECRET;
+    const req = { headers: {} } as AuthenticatedRequest;
+    const res = createResponseMock();
+    const next = createNextMock();
+
+    await authenticate(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'ServerError',
+      message: 'auth.errors.jwt_not_configured',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 when no session token is present', async () => {
+    const req = { headers: {} } as AuthenticatedRequest;
+    const res = createResponseMock();
+    const next = createNextMock();
+
+    await authenticate(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Unauthorized',
+      message: 'auth.errors.unauthorized',
+    });
+  });
+
+  test('logs error and returns 401 when token verification fails', async () => {
+    const req = {
+      headers: {
+        cookie: 'sessionToken=' + encodeURIComponent('invalid token'),
+      },
+    } as AuthenticatedRequest;
+    const res = createResponseMock();
+    const next = createNextMock();
+
+    vi.spyOn(jwt, 'verify').mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const loggerSpy = vi
+      .spyOn(logger, 'error')
+      .mockImplementation(() => undefined);
+
+    await authenticate(req, res, next);
+
+    expect(jwt.verify).toHaveBeenCalledWith('invalid token', 'secret', {
+      algorithms: ['HS256'],
+    });
+    expect(loggerSpy).toHaveBeenCalledWith('Authentication error', {
+      message: 'boom',
+    });
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Unauthorized',
+      message: 'auth.errors.unauthorized',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('returns 401 when user is not found', async () => {
+    const req = {
+      headers: { cookie: 'sessionToken=' + encodeURIComponent('valid-token') },
+    } as AuthenticatedRequest;
+    const res = createResponseMock();
+    const next = createNextMock();
+
+    vi.spyOn(jwt, 'verify').mockReturnValue({ id: 1 } as never);
+    vi.spyOn(userRepository, 'findUserById').mockResolvedValue(null);
+
+    await authenticate(req, res, next);
+
+    expect(userRepository.findUserById).toHaveBeenCalledWith(1);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Unauthorized',
+      message: 'auth.errors.unauthorized',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('attaches public user to request and calls next on success', async () => {
+    const req = {
+      headers: { cookie: 'sessionToken=' + encodeURIComponent('valid') },
+    } as AuthenticatedRequest;
+    const res = createResponseMock();
+    const next = createNextMock();
+
+    const dbUser: User = {
+      id: 1,
+      name: 'Alice',
+      email: 'alice@example.com',
+      password: 'hashed',
+      role: 'user',
+      language: 'es',
+      location: null,
+      searchRadius: null,
+    };
+    const publicUser: PublicUser = {
+      id: 1,
+      name: 'Alice',
+      email: 'alice@example.com',
+      role: 'user',
+      language: 'es',
+      location: null,
+      searchRadius: null,
+    };
+
+    vi.spyOn(jwt, 'verify').mockReturnValue({ id: 1 } as never);
+    vi.spyOn(userRepository, 'findUserById').mockResolvedValue(dbUser);
+    vi.spyOn(userRepository, 'toPublicUser').mockReturnValue(publicUser);
+
+    await authenticate(req, res, next);
+
+    expect(userRepository.findUserById).toHaveBeenCalledWith(1);
+    expect(userRepository.toPublicUser).toHaveBeenCalledWith(dbUser);
+    expect(req.user).toEqual(publicUser);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/tests/services/openLibrary.test.ts
+++ b/backend/tests/services/openLibrary.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  searchBooks,
+  checkBookExists,
+} from '../../src/services/openLibrary.js';
+
+describe('openLibrary service', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('searchBooks maps Open Library documents to domain books', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({
+        docs: [
+          {
+            title: 'Test Title',
+            author_name: ['Author One', 'Author Two'],
+            isbn: ['1234567890'],
+            publisher: ['Publisher Inc.'],
+            first_publish_year: 1999,
+          },
+        ],
+      }),
+    } as unknown as Response);
+
+    const books = await searchBooks('test query');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://openlibrary.org/search.json?q=test%20query&limit=10'
+    );
+    expect(books).toEqual([
+      {
+        title: 'Test Title',
+        author: 'Author One',
+        isbn: '1234567890',
+        publisher: 'Publisher Inc.',
+        publishedYear: 1999,
+      },
+    ]);
+  });
+
+  test('searchBooks defaults missing document fields to null', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      json: async () => ({
+        docs: [
+          {
+            title: 'Untitled',
+          },
+        ],
+      }),
+    } as unknown as Response);
+
+    const books = await searchBooks('missing fields');
+    expect(books).toEqual([
+      {
+        title: 'Untitled',
+        author: null,
+        isbn: null,
+        publisher: null,
+        publishedYear: null,
+      },
+    ]);
+  });
+
+  test('checkBookExists uses ISBN when provided', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      json: async () => ({ numFound: 1 }),
+    });
+
+    const exists = await checkBookExists(
+      { isbn: '9780140328721' },
+      { fetchFn }
+    );
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://openlibrary.org/search.json?q=isbn%3A9780140328721&limit=1'
+    );
+    expect(exists).toBe(true);
+  });
+
+  test('checkBookExists builds query from title and author when ISBN missing', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      json: async () => ({ numFound: 0 }),
+    });
+
+    const exists = await checkBookExists(
+      { title: 'Cien años de soledad', author: 'Gabriel García Márquez' },
+      { fetchFn }
+    );
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://openlibrary.org/search.json?q=Cien%20a%C3%B1os%20de%20soledad%20Gabriel%20Garc%C3%ADa%20M%C3%A1rquez&limit=1'
+    );
+    expect(exists).toBe(false);
+  });
+
+  test('checkBookExists returns false when no query parameter is provided', async () => {
+    const fetchFn = vi.fn();
+    const exists = await checkBookExists({}, { fetchFn });
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(exists).toBe(false);
+  });
+
+  test('checkBookExists returns false when fetch rejects', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('network error'));
+    const exists = await checkBookExists({ title: 'Libro' }, { fetchFn });
+    expect(exists).toBe(false);
+  });
+});

--- a/backend/tests/utils/logger.test.ts
+++ b/backend/tests/utils/logger.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test, vi } from 'vitest';
+import { logger } from '../../src/utils/logger.js';
+
+describe('logger utility', () => {
+  test('logs info messages with and without metadata', () => {
+    const consoleSpy = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+
+    logger.info('simple message');
+    logger.info('message with meta', { key: 'value' });
+
+    expect(consoleSpy).toHaveBeenNthCalledWith(1, 'simple message');
+    expect(consoleSpy).toHaveBeenNthCalledWith(2, 'message with meta', {
+      key: 'value',
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  test('logs error messages with and without metadata', () => {
+    const consoleSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    logger.error('error occurred');
+    logger.error('error with details', { code: 500 });
+
+    expect(consoleSpy).toHaveBeenNthCalledWith(1, 'error occurred');
+    expect(consoleSpy).toHaveBeenNthCalledWith(2, 'error with details', {
+      code: 500,
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -46,6 +46,10 @@ Feature 1.1 Cuenta y acceso
   - Éxito: login/logout confiable; sesión persistente controlada.
 - [~] S-1.3 Idioma base y copy claro (Must, E1; BR-100; Should BR-101 en E2)
   - Éxito: español neutral; glosario/etiquetas centralizadas.
+  - Actualización 2025-09-30: se sumaron pruebas del selector de idioma y la actualización remota de preferencias en frontend, garantizando persistencia en cookies y sincronización con la API.
+- [x] S-1.7 Cobertura automatizada de autenticación y servicios transversales (Should, E1; QA-01)
+  - Éxito: middleware de auth y servicios comunes protegidos por pruebas unitarias que fallan ante regresiones críticas.
+  - Actualización 2025-09-30: se añadieron tests de middleware de autenticación, servicio de Open Library y utilidades de logging para sostener respuestas i18n coherentes ante fallos.
 
 Feature 1.2 Perfil y privacidad
 

--- a/frontend/tests/api/language/language.service.test.ts
+++ b/frontend/tests/api/language/language.service.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { updateLanguage } from '@src/api/language/language.service'
+import { RELATIVE_API_ROUTES } from '@src/api/routes'
+
+const { postMock } = vi.hoisted(() => ({
+  postMock: vi.fn<(url: string, body: unknown) => Promise<unknown>>(),
+}))
+
+vi.mock('@src/api/axios', () => ({
+  apiClient: {
+    post: postMock,
+  },
+}))
+
+describe('language service', () => {
+  beforeEach(() => {
+    postMock.mockReset()
+  })
+
+  test('sends the selected language to the API', async () => {
+    postMock.mockResolvedValueOnce(undefined)
+
+    await updateLanguage('en')
+
+    expect(postMock).toHaveBeenCalledWith(RELATIVE_API_ROUTES.LANGUAGE.UPDATE, {
+      language: 'en',
+    })
+  })
+
+  test('propagates API errors', async () => {
+    const error = new Error('network error')
+    postMock.mockRejectedValueOnce(error)
+
+    await expect(updateLanguage('es')).rejects.toBe(error)
+  })
+})

--- a/frontend/tests/components/language-selector/LanguageSelector.test.tsx
+++ b/frontend/tests/components/language-selector/LanguageSelector.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { LanguageSelector } from '@src/components/language-selector/LanguageSelector'
+
+const changeLanguageMock = vi.fn()
+
+vi.mock('@hooks/language/useUserLanguage', () => ({
+  useUserLanguage: () => ({
+    language: 'es',
+    changeLanguage: changeLanguageMock,
+  }),
+}))
+
+describe('LanguageSelector', () => {
+  beforeEach(() => {
+    changeLanguageMock.mockClear()
+  })
+
+  test('renders language options with the current selection', () => {
+    render(<LanguageSelector />)
+
+    const select = screen.getByRole('combobox') as HTMLSelectElement
+    expect(select.value).toBe('es')
+    expect(screen.getByRole('option', { name: 'EN' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'ES' })).toBeInTheDocument()
+  })
+
+  test('changes language when selecting a different option', () => {
+    render(<LanguageSelector />)
+
+    const select = screen.getByRole('combobox') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'en' } })
+
+    expect(changeLanguageMock).toHaveBeenCalledWith('en')
+  })
+})

--- a/frontend/tests/hooks/language/useUserLanguage.test.ts
+++ b/frontend/tests/hooks/language/useUserLanguage.test.ts
@@ -1,0 +1,100 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mutateMock = vi.fn<(language: string) => void>()
+const getCookieMock = vi.fn<(name: string) => string | undefined>()
+const setCookieMock = vi.fn<(name: string, value: string) => void>()
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({
+    mutate: mutateMock,
+  }),
+}))
+
+vi.mock('@utils/cookies', () => ({
+  getCookie: getCookieMock,
+  setCookie: setCookieMock,
+  clearAllCookies: vi.fn(),
+  default: vi.fn(),
+}))
+
+const renderUseUserLanguage = async () => {
+  const { useUserLanguage } = await import(
+    '@src/hooks/language/useUserLanguage'
+  )
+  return renderHook(() => useUserLanguage())
+}
+
+describe('useUserLanguage', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mutateMock.mockReset()
+    getCookieMock.mockReset()
+    setCookieMock.mockReset()
+  })
+
+  test('initializes language from cookie when available', async () => {
+    getCookieMock.mockReturnValue('en')
+
+    const { result } = await renderUseUserLanguage()
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalledWith('en')
+    })
+
+    expect(setCookieMock).not.toHaveBeenCalled()
+    expect(result.current.language).toBe('es')
+  })
+
+  test('falls back to current i18n language when cookie is missing', async () => {
+    getCookieMock.mockReturnValue(undefined)
+
+    await renderUseUserLanguage()
+
+    await waitFor(() => {
+      expect(setCookieMock).toHaveBeenCalledWith('language', 'es')
+    })
+
+    expect(mutateMock).toHaveBeenCalledWith('es')
+  })
+
+  test('changes language and persists it when selecting a new value', async () => {
+    getCookieMock.mockReturnValue(undefined)
+
+    const { result } = await renderUseUserLanguage()
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalledWith('es')
+    })
+
+    mutateMock.mockClear()
+    setCookieMock.mockClear()
+
+    act(() => {
+      result.current.changeLanguage('en')
+    })
+
+    expect(setCookieMock).toHaveBeenCalledWith('language', 'en')
+    expect(mutateMock).toHaveBeenCalledWith('en')
+  })
+
+  test('does not trigger updates when selecting the current language', async () => {
+    getCookieMock.mockReturnValue(undefined)
+
+    const { result } = await renderUseUserLanguage()
+
+    await waitFor(() => {
+      expect(mutateMock).toHaveBeenCalledWith('es')
+    })
+
+    mutateMock.mockClear()
+    setCookieMock.mockClear()
+
+    act(() => {
+      result.current.changeLanguage('es')
+    })
+
+    expect(setCookieMock).not.toHaveBeenCalled()
+    expect(mutateMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -4,6 +4,11 @@ import { afterAll, afterEach, beforeAll, vi } from 'vitest'
 
 import { server } from '@mocks/server'
 
+let currentLanguage = 'es'
+const changeLanguageMock = vi.fn(async (lng: string) => {
+  currentLanguage = lng
+})
+
 if (typeof globalThis.ProgressEvent === 'undefined') {
   class ProgressEvent extends Event {
     constructor(type: string, eventInitDict?: EventInit) {
@@ -40,7 +45,12 @@ vi.mock('react-i18next', async () => {
           return value !== undefined ? String(value) : ''
         })
       },
-      i18n: { changeLanguage: () => Promise.resolve() },
+      i18n: {
+        changeLanguage: changeLanguageMock,
+        get language() {
+          return currentLanguage
+        },
+      },
     }),
     Trans: ({ children }: { children: React.ReactNode }) => children,
     initReactI18next: {
@@ -60,6 +70,8 @@ afterEach(() => {
     const name = eqPos > -1 ? cookie.slice(0, eqPos).trim() : cookie.trim()
     document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`
   })
+  currentLanguage = 'es'
+  changeLanguageMock.mockClear()
 })
 
 afterAll(() => server.close())


### PR DESCRIPTION
## Summary
- add frontend unit tests for the language service, selector component, and user language hook to cover preference persistence
- enhance the shared test setup to provide a stateful mock i18n instance used across language tests
- document the new frontend coverage for language preferences in the product backlog

## Testing
- `npm run test:backend` 
- `npm run test:frontend`
- `npm run format:backend`
- `npm run format:frontend`
