### PR TITLE
Log publish errors when book publication fails

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -81,6 +81,7 @@ Feature 3.1 Publicación y calidad del dato
   - Actualización 2025-10-05: se entregó el flujo completo en frontend (modal por ruta, stepper, autosave, preview e i18n) consumiendo mocks MSW; queda pendiente integrar con backend real y telemetría persistente.
   - Actualización 2025-10-06: se ajustó el autosave para evitar sobrescrituras del borrador al reanudar y se mejoró la accesibilidad del focus trap.
   - Actualización 2025-10-07: se reforzó la suite automatizada (MSW + RTL) cubriendo autosave, reanudación, publicación y errores, elevando la cobertura global del workspace por encima del 85% requerido.
+  - Actualización 2025-10-08: se registran fallas en consola al publicar para agilizar el diagnóstico sin perder la notificación en UI.
 - [~] S-3.2 Normalización asistida por ISBN/metadata (Should, E2; BR-22)
   - Éxito: autocompletado; reducción de duplicados/ambigüedades.
 - [ ] S-3.3 Contenidos permitidos/denegados (política editorial) (Must, E1; BR-24)

--- a/frontend/src/components/publish/PublishBookModal/PublishBookModal.tsx
+++ b/frontend/src/components/publish/PublishBookModal/PublishBookModal.tsx
@@ -438,7 +438,8 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
       toast.success(t('publishBook.published'))
       clear()
       onPublished(created.id)
-    } catch {
+    } catch (error) {
+      console.error('Failed to publish book', error)
       toast.error(t('publishBook.publishError'))
     }
   }


### PR DESCRIPTION
## Summary
- log publish errors to the console before showing the user-facing toast
- document the backlog update reflecting the improved error diagnostics in the publish flow

## Testing
- npm run test:frontend *(fails: Vitest cannot resolve the `lodash` dependency in the frontend workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1e722350832ead2b164cf4105f7e