### PR TITLE
Refactor publish book modal into modular components

### DIFF
--- a/backend/tests/middleware/auth.test.ts
+++ b/backend/tests/middleware/auth.test.ts
@@ -1,15 +1,15 @@
-import type { Response, NextFunction } from 'express';
+import type { NextFunction, Response } from 'express';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import jwt from 'jsonwebtoken';
 import {
   authenticate,
   type AuthenticatedRequest,
 } from '../../src/middleware/auth.js';
-import * as userRepository from '../../src/repositories/userRepository.js';
 import type {
   PublicUser,
   User,
 } from '../../src/repositories/userRepository.js';
+import * as userRepository from '../../src/repositories/userRepository.js';
 import { logger } from '../../src/utils/logger.js';
 
 describe('authenticate middleware', () => {
@@ -36,11 +36,10 @@ describe('authenticate middleware', () => {
   });
 
   function createResponseMock() {
-    const res = {
+    return {
       status: vi.fn().mockReturnThis(),
       json: vi.fn().mockReturnThis(),
     } as unknown as Response;
-    return res;
   }
 
   function createNextMock() {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -85,6 +85,7 @@ Feature 3.1 Publicación y calidad del dato
   - Actualización 2025-10-05: se entregó el flujo completo en frontend (modal por ruta, stepper, autosave, preview e i18n) consumiendo mocks MSW; queda pendiente integrar con backend real y telemetría persistente.
   - Actualización 2025-10-06: se ajustó el autosave para evitar sobrescrituras del borrador al reanudar y se mejoró la accesibilidad del focus trap.
   - Actualización 2025-10-07: se reforzó la suite automatizada (MSW + RTL) cubriendo autosave, reanudación, publicación y errores, elevando la cobertura global del workspace por encima del 85% requerido.
+  - Actualización 2025-10-08: se refactorizó el modal en componentes reutilizables, optimizando renders y mantenimiento sin alterar el flujo funcional.
 - [~] S-3.2 Normalización asistida por ISBN/metadata (Should, E2; BR-22)
   - Éxito: autocompletado; reducción de duplicados/ambigüedades.
 - [ ] S-3.3 Contenidos permitidos/denegados (política editorial) (Must, E1; BR-24)

--- a/frontend/src/components/publish/PublishBookModal/PublishBookModal.constants.ts
+++ b/frontend/src/components/publish/PublishBookModal/PublishBookModal.constants.ts
@@ -1,0 +1,78 @@
+import {
+  PublishBookDraftState,
+  PublishBookFormState,
+  PublishBookMetadata,
+  PublishBookOffer,
+  PublishBookStep,
+} from './PublishBookModal.types'
+
+export const STORAGE_KEY = 'entrelibros.publish.draft'
+
+export const initialMetadata: PublishBookMetadata = {
+  title: '',
+  author: '',
+  publisher: '',
+  year: '',
+  language: '',
+  format: '',
+  isbn: '',
+  coverUrl: '',
+}
+
+export const initialOffer: PublishBookOffer = {
+  sale: false,
+  donation: false,
+  trade: false,
+  priceAmount: '',
+  priceCurrency: 'ARS',
+  condition: '',
+  tradePreferences: [],
+  notes: '',
+  availability: 'public',
+  delivery: {
+    nearBookCorner: true,
+    inPerson: true,
+    shipping: false,
+    shippingPayer: 'owner',
+  },
+}
+
+export const initialState: PublishBookFormState = {
+  metadata: initialMetadata,
+  offer: initialOffer,
+  images: [],
+  manualMode: false,
+  searchQuery: '',
+  step: 'identify',
+  acceptedTerms: false,
+}
+
+export const genres = [
+  'fiction',
+  'nonfiction',
+  'fantasy',
+  'history',
+  'science',
+  'romance',
+  'selfHelp',
+] as const
+
+export const stepOrder: PublishBookStep[] = ['identify', 'offer', 'review']
+
+export const stepIndex: Record<PublishBookStep, number> = {
+  identify: 0,
+  offer: 1,
+  review: 2,
+}
+
+export const toSerializableDraft = (
+  state: PublishBookFormState
+): PublishBookDraftState => ({
+  ...state,
+  images: state.images.map(({ id, url, source, name }) => ({
+    id,
+    url,
+    source,
+    name,
+  })),
+})

--- a/frontend/src/components/publish/PublishBookModal/PublishBookModal.tsx
+++ b/frontend/src/components/publish/PublishBookModal/PublishBookModal.tsx
@@ -3,6 +3,7 @@ import { usePublishBook } from '@hooks/api/usePublishBook'
 import { useFocusTrap } from '@hooks/useFocusTrap'
 import { usePublishDraft } from '@hooks/usePublishDraft'
 import { stripDraftMeta } from '@utils/drafts'
+import isEqual from 'lodash/isEqual'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'react-toastify'
@@ -48,9 +49,6 @@ type PublishBookModalProps = {
 
 const usePublishBookDraft = () =>
   usePublishDraft<PublishBookDraftState>({ storageKey: STORAGE_KEY })
-
-const areDraftsEqual = (a: PublishBookDraftState, b: PublishBookDraftState) =>
-  JSON.stringify(a) === JSON.stringify(b)
 
 const usePublishState = (draft: PublishBookDraftState | null) => {
   const [state, setState] = useState<PublishBookFormState>(initialState)
@@ -159,7 +157,7 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
   const baseState = useMemo(() => sanitizeDraft(draft), [draft])
 
   const closeWithConfirmation = useCallback(() => {
-    const hasChanges = !areDraftsEqual(serializableState, baselineDraft)
+    const hasChanges = !isEqual(serializableState, baselineDraft)
     if (hasChanges) {
       const confirmed = window.confirm(t('publishBook.confirmClose'))
       if (!confirmed) {
@@ -178,7 +176,7 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
   useEffect(() => {
     if (!isOpen) return
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!areDraftsEqual(serializableState, baselineDraft)) {
+      if (!isEqual(serializableState, baselineDraft)) {
         event.preventDefault()
         event.returnValue = ''
       }
@@ -191,7 +189,7 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
 
   useEffect(() => {
     if (!isOpen || showDraftPrompt || !autosaveEnabled) return
-    if (areDraftsEqual(serializableState, baselineDraft)) return
+    if (isEqual(serializableState, baselineDraft)) return
     scheduleSave(serializableState)
   }, [
     autosaveEnabled,

--- a/frontend/src/components/publish/PublishBookModal/PublishBookModal.tsx
+++ b/frontend/src/components/publish/PublishBookModal/PublishBookModal.tsx
@@ -32,7 +32,6 @@ import {
   PublishBookImage,
   PublishBookMetadata,
   PublishBookOffer,
-  PublishBookStep,
 } from './PublishBookModal.types'
 import {
   ensureCover,
@@ -534,7 +533,7 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
             <PublishBookStepper
               currentStep={state.step}
               t={t}
-              stepOrder={stepOrder as PublishBookStep[]}
+              stepOrder={stepOrder}
               stepIndex={stepIndex}
             />
 

--- a/frontend/src/components/publish/PublishBookModal/PublishBookModal.tsx
+++ b/frontend/src/components/publish/PublishBookModal/PublishBookModal.tsx
@@ -1,10 +1,8 @@
-import { BookCard } from '@components/book/BookCard'
 import { useBookSearch } from '@hooks/api/useBookSearch'
 import { usePublishBook } from '@hooks/api/usePublishBook'
 import { useFocusTrap } from '@hooks/useFocusTrap'
 import { usePublishDraft } from '@hooks/usePublishDraft'
 import { stripDraftMeta } from '@utils/drafts'
-import { isEqual } from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'react-toastify'
@@ -13,6 +11,19 @@ import { PublishBookPayload } from '@src/api/books/publishBook.types'
 import { ApiBookSearchResult } from '@src/api/books/searchBooks.types'
 import { MAX_IMAGES_UPLOAD } from '@src/constants/constants'
 
+import { IdentifyStep } from './components/IdentifyStep'
+import { OfferStep } from './components/OfferStep'
+import { PublishBookStepper } from './components/PublishBookStepper'
+import { ResumeDraftPrompt } from './components/ResumeDraftPrompt'
+import { ReviewStep } from './components/ReviewStep'
+import {
+  STORAGE_KEY,
+  genres,
+  initialState,
+  stepIndex,
+  stepOrder,
+  toSerializableDraft,
+} from './PublishBookModal.constants'
 import styles from './PublishBookModal.module.scss'
 import {
   PublishBookDraftState,
@@ -22,57 +33,12 @@ import {
   PublishBookOffer,
   PublishBookStep,
 } from './PublishBookModal.types'
-
-const STORAGE_KEY = 'entrelibros.publish.draft'
-
-const initialMetadata: PublishBookMetadata = {
-  title: '',
-  author: '',
-  publisher: '',
-  year: '',
-  language: '',
-  format: '',
-  isbn: '',
-  coverUrl: '',
-}
-
-const initialOffer: PublishBookOffer = {
-  sale: false,
-  donation: false,
-  trade: false,
-  priceAmount: '',
-  priceCurrency: 'ARS',
-  condition: '',
-  tradePreferences: [],
-  notes: '',
-  availability: 'public',
-  delivery: {
-    nearBookCorner: true,
-    inPerson: true,
-    shipping: false,
-    shippingPayer: 'owner',
-  },
-}
-
-const initialState: PublishBookFormState = {
-  metadata: initialMetadata,
-  offer: initialOffer,
-  images: [],
-  manualMode: false,
-  searchQuery: '',
-  step: 'identify',
-  acceptedTerms: false,
-}
-
-const genres = [
-  'fiction',
-  'nonfiction',
-  'fantasy',
-  'history',
-  'science',
-  'romance',
-  'selfHelp',
-]
+import {
+  ensureCover,
+  getPreviewCover,
+  sanitizeDraft,
+} from './PublishBookModal.utils'
+import { useDebouncedValue } from './useDebouncedValue'
 
 type PublishBookModalProps = {
   isOpen: boolean
@@ -80,100 +46,35 @@ type PublishBookModalProps = {
   onPublished: (bookId: string) => void
 }
 
-const toSerializableDraft = (
-  state: PublishBookFormState
-): PublishBookDraftState => ({
-  ...state,
-  images: state.images.map(({ id, url, source, name }) => ({
-    id,
-    url,
-    source,
-    name,
-  })),
-})
+const usePublishBookDraft = () =>
+  usePublishDraft<PublishBookDraftState>({ storageKey: STORAGE_KEY })
 
-const sanitizeDraft = (
-  draft: PublishBookDraftState | null
-): PublishBookFormState => {
-  if (!draft) return initialState
-  return {
-    ...initialState,
-    ...draft,
-    metadata: { ...initialMetadata, ...draft.metadata },
-    offer: { ...initialOffer, ...draft.offer },
-  }
-}
+const areDraftsEqual = (a: PublishBookDraftState, b: PublishBookDraftState) =>
+  JSON.stringify(a) === JSON.stringify(b)
 
-const ensureCover = (images: PublishBookImage[], coverUrl?: string) => {
-  if (coverUrl && !images.some((image) => image.source === 'cover')) {
-    return [
-      {
-        id: `cover-${Date.now()}`,
-        url: coverUrl,
-        source: 'cover' as const,
-      },
-      ...images,
-    ]
-  }
-  return images
-}
-
-const getPreviewCover = (images: PublishBookImage[], fallback?: string) => {
-  if (images.length === 0) return fallback ?? ''
-  const cover = images.find((image) => image.source === 'cover')
-  return (cover ?? images[0]).url
-}
-
-const useDebouncedValue = (value: string, delay = 400) => {
-  const [debounced, setDebounced] = useState(value)
-
-  useEffect(() => {
-    const timeout = window.setTimeout(() => setDebounced(value), delay)
-    return () => window.clearTimeout(timeout)
-  }, [value, delay])
-
-  return debounced
-}
-
-export const PublishBookModal: React.FC<PublishBookModalProps> = ({
-  isOpen,
-  onClose,
-  onPublished,
-}) => {
-  const { t, i18n } = useTranslation()
-  const {
-    draft: storedDraft,
-    saveNow,
-    scheduleSave,
-    clear,
-  } = usePublishDraft<PublishBookDraftState>({ storageKey: STORAGE_KEY })
-  const draft = useMemo(() => stripDraftMeta(storedDraft), [storedDraft])
+const usePublishState = (draft: PublishBookDraftState | null) => {
   const [state, setState] = useState<PublishBookFormState>(initialState)
   const [showDraftPrompt, setShowDraftPrompt] = useState(false)
   const [autosaveEnabled, setAutosaveEnabled] = useState<boolean>(() => !draft)
-  const modalRef = useRef<HTMLDivElement>(null)
+
+  return {
+    state,
+    setState,
+    showDraftPrompt,
+    setShowDraftPrompt,
+    autosaveEnabled,
+    setAutosaveEnabled,
+  }
+}
+
+const useDraftInitialization = (
+  isOpen: boolean,
+  draft: PublishBookDraftState | null,
+  setState: React.Dispatch<React.SetStateAction<PublishBookFormState>>,
+  setShowDraftPrompt: React.Dispatch<React.SetStateAction<boolean>>,
+  setAutosaveEnabled: React.Dispatch<React.SetStateAction<boolean>>
+) => {
   const initializedRef = useRef(false)
-
-  const baselineDraft = useMemo<PublishBookDraftState>(
-    () => draft ?? toSerializableDraft(initialState),
-    [draft]
-  )
-  const serializableState = useMemo<PublishBookDraftState>(
-    () => toSerializableDraft(state),
-    [state]
-  )
-
-  const debouncedQuery = useDebouncedValue(state.searchQuery)
-  const {
-    data: results,
-    isFetching,
-    isError,
-    refetch,
-  } = useBookSearch(debouncedQuery)
-
-  const { mutateAsync, isPending } = usePublishBook()
-
-  const baseState = useMemo(() => sanitizeDraft(draft), [draft])
 
   useEffect(() => {
     if (!isOpen) {
@@ -193,8 +94,10 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
       setState(initialState)
       setAutosaveEnabled(true)
     }
-  }, [draft, isOpen])
+  }, [draft, isOpen, setAutosaveEnabled, setShowDraftPrompt, setState])
+}
 
+const useBodyScrollLock = (isOpen: boolean) => {
   useEffect(() => {
     if (!isOpen) return
     document.body.style.overflow = 'hidden'
@@ -202,9 +105,61 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
       document.body.style.overflow = ''
     }
   }, [isOpen])
+}
 
-  const closeWithConfirmation = () => {
-    const hasChanges = !isEqual(serializableState, baselineDraft)
+export const PublishBookModal: React.FC<PublishBookModalProps> = ({
+  isOpen,
+  onClose,
+  onPublished,
+}) => {
+  const { t, i18n } = useTranslation()
+  const {
+    draft: storedDraft,
+    saveNow,
+    scheduleSave,
+    clear,
+  } = usePublishBookDraft()
+  const draft = useMemo(() => stripDraftMeta(storedDraft), [storedDraft])
+  const {
+    state,
+    setState,
+    showDraftPrompt,
+    setShowDraftPrompt,
+    autosaveEnabled,
+    setAutosaveEnabled,
+  } = usePublishState(draft)
+  const modalRef = useRef<HTMLDivElement>(null)
+
+  useDraftInitialization(
+    isOpen,
+    draft,
+    setState,
+    setShowDraftPrompt,
+    setAutosaveEnabled
+  )
+  useBodyScrollLock(isOpen)
+
+  const baselineDraft = useMemo<PublishBookDraftState>(
+    () => draft ?? toSerializableDraft(initialState),
+    [draft]
+  )
+  const serializableState = useMemo<PublishBookDraftState>(
+    () => toSerializableDraft(state),
+    [state]
+  )
+
+  const debouncedQuery = useDebouncedValue(state.searchQuery)
+  const {
+    data: results,
+    isFetching,
+    isError,
+    refetch,
+  } = useBookSearch(debouncedQuery)
+  const { mutateAsync, isPending } = usePublishBook()
+  const baseState = useMemo(() => sanitizeDraft(draft), [draft])
+
+  const closeWithConfirmation = useCallback(() => {
+    const hasChanges = !areDraftsEqual(serializableState, baselineDraft)
     if (hasChanges) {
       const confirmed = window.confirm(t('publishBook.confirmClose'))
       if (!confirmed) {
@@ -212,7 +167,7 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
       }
     }
     onClose()
-  }
+  }, [baselineDraft, onClose, serializableState, t])
 
   useFocusTrap({
     containerRef: modalRef,
@@ -223,7 +178,7 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
   useEffect(() => {
     if (!isOpen) return
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!isEqual(serializableState, baselineDraft)) {
+      if (!areDraftsEqual(serializableState, baselineDraft)) {
         event.preventDefault()
         event.returnValue = ''
       }
@@ -236,7 +191,7 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
 
   useEffect(() => {
     if (!isOpen || showDraftPrompt || !autosaveEnabled) return
-    if (isEqual(serializableState, baselineDraft)) return
+    if (areDraftsEqual(serializableState, baselineDraft)) return
     scheduleSave(serializableState)
   }, [
     autosaveEnabled,
@@ -247,158 +202,216 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
     showDraftPrompt,
   ])
 
-  const updateMetadata = (update: Partial<PublishBookMetadata>) => {
-    setAutosaveEnabled(true)
-    setState((prev) => {
-      const metadata = { ...prev.metadata, ...update }
-      const nextImages = ensureCover(prev.images, metadata.coverUrl)
-      return { ...prev, metadata, images: nextImages }
-    })
-  }
+  const handleBlur = useCallback<React.FocusEventHandler<HTMLElement>>(() => {
+    if (!autosaveEnabled) return
+    scheduleSave(serializableState)
+  }, [autosaveEnabled, scheduleSave, serializableState])
 
-  const updateOffer = (update: Partial<PublishBookOffer>) => {
-    setAutosaveEnabled(true)
-    setState((prev) => ({
-      ...prev,
-      offer: { ...prev.offer, ...update },
-    }))
-  }
+  const updateMetadata = useCallback(
+    (update: Partial<PublishBookMetadata>) => {
+      setAutosaveEnabled(true)
+      setState((prev) => {
+        const metadata = { ...prev.metadata, ...update }
+        const nextImages = ensureCover(prev.images, metadata.coverUrl)
+        return { ...prev, metadata, images: nextImages }
+      })
+    },
+    [setAutosaveEnabled, setState]
+  )
 
-  const updateDelivery = (update: Partial<PublishBookOffer['delivery']>) => {
-    setAutosaveEnabled(true)
-    setState((prev) => ({
-      ...prev,
-      offer: { ...prev.offer, delivery: { ...prev.offer.delivery, ...update } },
-    }))
-  }
+  const updateOffer = useCallback(
+    (update: Partial<PublishBookOffer>) => {
+      setAutosaveEnabled(true)
+      setState((prev) => ({
+        ...prev,
+        offer: { ...prev.offer, ...update },
+      }))
+    },
+    [setAutosaveEnabled, setState]
+  )
 
-  const handleResult = (result: ApiBookSearchResult) => {
-    setState((prev) => ({
-      ...prev,
-      metadata: {
-        ...prev.metadata,
-        title: result.title ?? prev.metadata.title,
-        author: result.author ?? prev.metadata.author,
-        publisher: result.publisher ?? prev.metadata.publisher,
-        year: result.year ? String(result.year) : prev.metadata.year,
-        language:
-          result.language ?? prev.metadata.language ?? i18n.language ?? '',
-        format: result.format ?? prev.metadata.format,
-        isbn: result.isbn ?? prev.metadata.isbn,
-        coverUrl: result.coverUrl ?? prev.metadata.coverUrl,
-      },
-      manualMode: false,
-      images: ensureCover(
-        prev.images,
-        result.coverUrl ?? prev.metadata.coverUrl
-      ),
-    }))
-    toast.info(t('publishBook.prefilled'))
-    setAutosaveEnabled(true)
-  }
+  const updateDelivery = useCallback(
+    (update: Partial<PublishBookOffer['delivery']>) => {
+      setAutosaveEnabled(true)
+      setState((prev) => ({
+        ...prev,
+        offer: {
+          ...prev.offer,
+          delivery: { ...prev.offer.delivery, ...update },
+        },
+      }))
+    },
+    [setAutosaveEnabled, setState]
+  )
 
-  const handleFiles = async (files: FileList | null) => {
-    if (!files) return
-    const fileArray = Array.from(files).slice(0, MAX_IMAGES_UPLOAD)
-    const uploads: PublishBookImage[] = await Promise.all(
-      fileArray.map(
-        (file, index) =>
-          new Promise<PublishBookImage>((resolve, reject) => {
-            const reader = new FileReader()
-            reader.onload = () =>
-              resolve({
-                id: `${file.name}-${Date.now()}-${index}`,
-                url: String(reader.result),
-                source: 'upload',
-                name: file.name,
-              })
-            reader.onerror = () =>
-              reject(reader.error ?? new Error('Failed to read file'))
-            reader.readAsDataURL(file)
-          })
+  const toggleTradePreference = useCallback(
+    (genre: PublishBookOffer['tradePreferences'][number]) => {
+      setAutosaveEnabled(true)
+      setState((prev) => {
+        const isActive = prev.offer.tradePreferences.includes(genre)
+        const tradePreferences = isActive
+          ? prev.offer.tradePreferences.filter((item) => item !== genre)
+          : [...prev.offer.tradePreferences, genre]
+        return {
+          ...prev,
+          offer: { ...prev.offer, tradePreferences },
+        }
+      })
+    },
+    [setAutosaveEnabled, setState]
+  )
+
+  const handleResult = useCallback(
+    (result: ApiBookSearchResult) => {
+      setState((prev) => ({
+        ...prev,
+        metadata: {
+          ...prev.metadata,
+          title: result.title ?? prev.metadata.title,
+          author: result.author ?? prev.metadata.author,
+          publisher: result.publisher ?? prev.metadata.publisher,
+          year: result.year ? String(result.year) : prev.metadata.year,
+          language:
+            result.language ?? prev.metadata.language ?? i18n.language ?? '',
+          format: result.format ?? prev.metadata.format,
+          isbn: result.isbn ?? prev.metadata.isbn,
+          coverUrl: result.coverUrl ?? prev.metadata.coverUrl,
+        },
+        manualMode: false,
+        images: ensureCover(
+          prev.images,
+          result.coverUrl ?? prev.metadata.coverUrl
+        ),
+      }))
+      toast.info(t('publishBook.prefilled'))
+      setAutosaveEnabled(true)
+    },
+    [i18n.language, setAutosaveEnabled, setState, t]
+  )
+
+  const handleFiles = useCallback(
+    async (files: FileList | null) => {
+      if (!files) return
+      const fileArray = Array.from(files).slice(0, MAX_IMAGES_UPLOAD)
+      const uploads = await Promise.all(
+        fileArray.map(
+          (file, index) =>
+            new Promise<PublishBookImage>((resolve, reject) => {
+              const reader = new FileReader()
+              reader.onload = () =>
+                resolve({
+                  id: `${file.name}-${Date.now()}-${index}`,
+                  url: String(reader.result),
+                  source: 'upload',
+                  name: file.name,
+                })
+              reader.onerror = () =>
+                reject(reader.error ?? new Error('Failed to read file'))
+              reader.readAsDataURL(file)
+            })
+        )
       )
-    )
-    setState((prev) => {
-      const nextImages = [...prev.images, ...uploads].slice(
-        0,
-        MAX_IMAGES_UPLOAD
-      )
-      return { ...prev, images: nextImages }
-    })
-    setAutosaveEnabled(true)
-  }
+      setState((prev) => {
+        const nextImages = [...prev.images, ...uploads].slice(
+          0,
+          MAX_IMAGES_UPLOAD
+        )
+        return { ...prev, images: nextImages }
+      })
+      setAutosaveEnabled(true)
+    },
+    [setAutosaveEnabled, setState]
+  )
 
-  const removeImage = (id: string) => {
-    setAutosaveEnabled(true)
-    setState((prev) => ({
-      ...prev,
-      images: prev.images.filter((image) => image.id !== id),
-    }))
-  }
+  const removeImage = useCallback(
+    (id: string) => {
+      setAutosaveEnabled(true)
+      setState((prev) => ({
+        ...prev,
+        images: prev.images.filter((image) => image.id !== id),
+      }))
+    },
+    [setAutosaveEnabled, setState]
+  )
 
-  const nextStep = () => {
+  const nextStep = useCallback(() => {
     setAutosaveEnabled(true)
     setState((prev) => ({
       ...prev,
       step: prev.step === 'identify' ? 'offer' : 'review',
     }))
-  }
+  }, [setAutosaveEnabled, setState])
 
-  const previousStep = () => {
+  const previousStep = useCallback(() => {
     setAutosaveEnabled(true)
     setState((prev) => ({
       ...prev,
       step: prev.step === 'review' ? 'offer' : 'identify',
     }))
-  }
+  }, [setAutosaveEnabled, setState])
 
-  const imagesCount = state.images.length
-  const coverUrl = getPreviewCover(state.images, state.metadata.coverUrl)
+  const coverUrl = useMemo(
+    () => getPreviewCover(state.images, state.metadata.coverUrl),
+    [state.images, state.metadata.coverUrl]
+  )
 
-  const identifyErrors: Record<string, string> = {}
-  if (!state.metadata.title.trim()) {
-    identifyErrors.title = t('publishBook.errors.title')
-  }
-  if (!state.metadata.author.trim()) {
-    identifyErrors.author = t('publishBook.errors.author')
-  }
-  if (!state.metadata.language.trim()) {
-    identifyErrors.language = t('publishBook.errors.language')
-  }
-  if (!state.metadata.format.trim()) {
-    identifyErrors.format = t('publishBook.errors.format')
-  }
-  if (!coverUrl) {
-    identifyErrors.images = t('publishBook.errors.image')
-  }
-
-  const canProceedIdentify = Object.keys(identifyErrors).length === 0
-
-  const offerErrors: Record<string, string> = {}
-  if (!state.offer.condition) {
-    offerErrors.condition = t('publishBook.errors.condition')
-  }
-  if (!state.offer.sale && !state.offer.trade && !state.offer.donation) {
-    offerErrors.modes = t('publishBook.errors.modes')
-  }
-  if (state.offer.sale) {
-    const amount = Number(state.offer.priceAmount)
-    if (!state.offer.priceAmount || Number.isNaN(amount) || amount <= 0) {
-      offerErrors.price = t('publishBook.errors.price')
+  const identifyErrors = useMemo(() => {
+    const errors: Record<string, string> = {}
+    if (!state.metadata.title.trim()) {
+      errors.title = t('publishBook.errors.title')
     }
-  }
+    if (!state.metadata.author.trim()) {
+      errors.author = t('publishBook.errors.author')
+    }
+    if (!state.metadata.language.trim()) {
+      errors.language = t('publishBook.errors.language')
+    }
+    if (!state.metadata.format.trim()) {
+      errors.format = t('publishBook.errors.format')
+    }
+    if (!coverUrl) {
+      errors.images = t('publishBook.errors.image')
+    }
+    return errors
+  }, [coverUrl, state.metadata, t])
 
-  const canProceedOffer = Object.keys(offerErrors).length === 0
+  const offerErrors = useMemo(() => {
+    const errors: Record<string, string> = {}
+    if (!state.offer.condition) {
+      errors.condition = t('publishBook.errors.condition')
+    }
+    if (!state.offer.sale && !state.offer.trade && !state.offer.donation) {
+      errors.modes = t('publishBook.errors.modes')
+    }
+    if (state.offer.sale) {
+      const amount = Number(state.offer.priceAmount)
+      if (!state.offer.priceAmount || Number.isNaN(amount) || amount <= 0) {
+        errors.price = t('publishBook.errors.price')
+      }
+    }
+    return errors
+  }, [state.offer, t])
 
-  const publishDisabled = !state.acceptedTerms || isPending
+  const canProceedIdentify = useMemo(
+    () => Object.keys(identifyErrors).length === 0,
+    [identifyErrors]
+  )
+  const canProceedOffer = useMemo(
+    () => Object.keys(offerErrors).length === 0,
+    [offerErrors]
+  )
+  const publishDisabled = useMemo(
+    () => !state.acceptedTerms || isPending,
+    [isPending, state.acceptedTerms]
+  )
 
-  const saveDraft = () => {
+  const handleSaveDraft = useCallback(() => {
     setAutosaveEnabled(true)
     saveNow(serializableState)
     toast.success(t('publishBook.draftSaved'))
-  }
+  }, [saveNow, serializableState, setAutosaveEnabled, t])
 
-  const handlePublish = async () => {
+  const handlePublish = useCallback(async () => {
     const payload: PublishBookPayload = {
       metadata: {
         title: state.metadata.title,
@@ -443,58 +456,56 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
     } catch {
       toast.error(t('publishBook.publishError'))
     }
-  }
+  }, [clear, coverUrl, mutateAsync, onPublished, state, t])
 
-  const stepIndex: Record<PublishBookStep, number> = {
-    identify: 0,
-    offer: 1,
-    review: 2,
-  }
-
-  const resumeDraft = () => {
+  const resumeDraft = useCallback(() => {
     setState(baseState)
     setShowDraftPrompt(false)
     setAutosaveEnabled(true)
-  }
+  }, [baseState, setAutosaveEnabled, setShowDraftPrompt, setState])
 
-  const discardDraft = () => {
+  const discardDraft = useCallback(() => {
     clear()
     setState(initialState)
     setShowDraftPrompt(false)
     setAutosaveEnabled(true)
-  }
+  }, [clear, setAutosaveEnabled, setShowDraftPrompt, setState])
 
-  // Single memoized blur handler reused across all inputs
-  const handleBlur = useCallback<React.FocusEventHandler<HTMLElement>>(() => {
-    // Pass the current serializable draft to scheduleSave
-    scheduleSave(serializableState)
-  }, [scheduleSave, serializableState])
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setState((prev) => ({ ...prev, searchQuery: value }))
+    },
+    [setState]
+  )
+
+  const handleManualModeToggle = useCallback(
+    (checked: boolean) => {
+      setState((prev) => ({ ...prev, manualMode: checked }))
+    },
+    [setState]
+  )
+
+  const handleRetrySearch = useCallback(() => {
+    void refetch()
+  }, [refetch])
+
+  const handleAcceptedTermsChange = useCallback(
+    (checked: boolean) => {
+      setState((prev) => ({ ...prev, acceptedTerms: checked }))
+    },
+    [setState]
+  )
 
   if (!isOpen) return null
 
   return (
     <div className={styles.overlay} role="presentation" aria-hidden={!isOpen}>
       {showDraftPrompt ? (
-        <div className={styles.resumePrompt} role="dialog" aria-modal="true">
-          <h2>{t('publishBook.resume.title')}</h2>
-          <p>{t('publishBook.resume.description')}</p>
-          <div className={styles.resumeActions}>
-            <button
-              type="button"
-              className={styles.secondaryButton}
-              onClick={discardDraft}
-            >
-              {t('publishBook.resume.discard')}
-            </button>
-            <button
-              type="button"
-              className={styles.primaryButton}
-              onClick={resumeDraft}
-            >
-              {t('publishBook.resume.continue')}
-            </button>
-          </div>
-        </div>
+        <ResumeDraftPrompt
+          t={t}
+          onDiscard={discardDraft}
+          onResume={resumeDraft}
+        />
       ) : (
         <div
           className={styles.modal}
@@ -522,641 +533,59 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
           </header>
 
           <section className={styles.content}>
-            <div
-              className={styles.stepper}
-              role="tablist"
-              aria-label={t('publishBook.progress')}
-            >
-              {(['identify', 'offer', 'review'] as PublishBookStep[]).map(
-                (step) => (
-                  <div key={step} className={styles.step}>
-                    <span
-                      className={`${styles.stepIndicator} ${
-                        step === state.step ? styles.stepActive : ''
-                      }`.trim()}
-                      aria-hidden="true"
-                    >
-                      {stepIndex[step] + 1}
-                    </span>
-                    <div>
-                      <div className={styles.stepLabel}>
-                        {t(`publishBook.steps.${step}.title`)}
-                      </div>
-                      <div className={styles.stepDescription}>
-                        {t(`publishBook.steps.${step}.description`)}
-                      </div>
-                    </div>
-                  </div>
-                )
-              )}
-            </div>
+            <PublishBookStepper
+              currentStep={state.step}
+              t={t}
+              stepOrder={stepOrder as PublishBookStep[]}
+              stepIndex={stepIndex}
+            />
 
             <div className={styles.stepContent}>
               {state.step === 'identify' && (
-                <div className={styles.stepLayout}>
-                  <div>
-                    <div className={styles.formGroup}>
-                      <label htmlFor="publish-search">
-                        {t('publishBook.search.label')}
-                      </label>
-                      <input
-                        id="publish-search"
-                        type="search"
-                        className={styles.input}
-                        placeholder={t('publishBook.search.placeholder') ?? ''}
-                        value={state.searchQuery}
-                        onChange={(event) =>
-                          setState((prev) => ({
-                            ...prev,
-                            searchQuery: event.target.value,
-                          }))
-                        }
-                        onBlur={handleBlur}
-                      />
-                    </div>
-                    {isFetching && (
-                      <div className={styles.loadingRow} role="status">
-                        <span className={styles.spinner} aria-hidden />
-                        <span>{t('publishBook.search.loading')}</span>
-                      </div>
-                    )}
-                    {isError && (
-                      <div className={styles.error} role="alert">
-                        {t('publishBook.search.error')}{' '}
-                        <button
-                          type="button"
-                          className={styles.ghostButton}
-                          onClick={() => refetch()}
-                        >
-                          {t('publishBook.search.retry')}
-                        </button>
-                      </div>
-                    )}
-                    {results && results.length === 0 && (
-                      <p className={styles.toastInline}>
-                        {t('publishBook.search.empty')}
-                      </p>
-                    )}
-                    {results && results.length > 0 && (
-                      <div className={styles.searchResults}>
-                        {results.map((book) => (
-                          <div key={book.id} className={styles.searchResult}>
-                            {book.coverUrl ? (
-                              <img
-                                src={book.coverUrl}
-                                alt={t('publishBook.search.cover', {
-                                  title: book.title,
-                                })}
-                                className={styles.searchCover}
-                              />
-                            ) : (
-                              <div
-                                className={styles.searchCover}
-                                aria-hidden="true"
-                              />
-                            )}
-                            <div className={styles.searchMeta}>
-                              <strong>{book.title}</strong>
-                              <span>
-                                {book.author}
-                                {book.year ? ` · ${book.year}` : ''}
-                              </span>
-                            </div>
-                            <button
-                              type="button"
-                              className={styles.searchButton}
-                              onClick={() => handleResult(book)}
-                            >
-                              {t('publishBook.search.use')}
-                            </button>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-
-                    <div className={styles.manualToggle}>
-                      <input
-                        type="checkbox"
-                        id="publish-manual"
-                        checked={state.manualMode}
-                        onChange={(event) =>
-                          setState((prev) => ({
-                            ...prev,
-                            manualMode: event.target.checked,
-                          }))
-                        }
-                      />
-                      <label
-                        htmlFor="publish-manual"
-                        className={styles.switchLabel}
-                      >
-                        {t('publishBook.manualToggle')}
-                      </label>
-                    </div>
-                  </div>
-
-                  <div className={styles.formGrid}>
-                    <div className={styles.formGroup}>
-                      <label htmlFor="publish-title">
-                        {t('publishBook.fields.title')}
-                      </label>
-                      <input
-                        id="publish-title"
-                        className={styles.input}
-                        value={state.metadata.title}
-                        onChange={(event) =>
-                          updateMetadata({ title: event.target.value })
-                        }
-                        onBlur={handleBlur}
-                        required
-                        aria-invalid={identifyErrors.title ? 'true' : 'false'}
-                      />
-                      {identifyErrors.title && (
-                        <span className={styles.error} role="alert">
-                          {identifyErrors.title}
-                        </span>
-                      )}
-                    </div>
-                    <div className={styles.formGroup}>
-                      <label htmlFor="publish-author">
-                        {t('publishBook.fields.author')}
-                      </label>
-                      <input
-                        id="publish-author"
-                        className={styles.input}
-                        value={state.metadata.author}
-                        onChange={(event) =>
-                          updateMetadata({ author: event.target.value })
-                        }
-                        onBlur={handleBlur}
-                        required
-                        aria-invalid={identifyErrors.author ? 'true' : 'false'}
-                      />
-                      {identifyErrors.author && (
-                        <span className={styles.error} role="alert">
-                          {identifyErrors.author}
-                        </span>
-                      )}
-                    </div>
-                    <div className={styles.formGroup}>
-                      <label htmlFor="publish-language">
-                        {t('publishBook.fields.language')}
-                      </label>
-                      <input
-                        id="publish-language"
-                        className={styles.input}
-                        value={state.metadata.language}
-                        onChange={(event) =>
-                          updateMetadata({ language: event.target.value })
-                        }
-                        onBlur={handleBlur}
-                        required
-                        aria-invalid={
-                          identifyErrors.language ? 'true' : 'false'
-                        }
-                      />
-                      {identifyErrors.language && (
-                        <span className={styles.error} role="alert">
-                          {identifyErrors.language}
-                        </span>
-                      )}
-                    </div>
-                    <div className={styles.formGroup}>
-                      <label htmlFor="publish-format">
-                        {t('publishBook.fields.format')}
-                      </label>
-                      <input
-                        id="publish-format"
-                        className={styles.input}
-                        value={state.metadata.format}
-                        onChange={(event) =>
-                          updateMetadata({ format: event.target.value })
-                        }
-                        onBlur={handleBlur}
-                        required
-                        aria-invalid={identifyErrors.format ? 'true' : 'false'}
-                      />
-                      {identifyErrors.format && (
-                        <span className={styles.error} role="alert">
-                          {identifyErrors.format}
-                        </span>
-                      )}
-                    </div>
-                    <div className={styles.formGroup}>
-                      <label htmlFor="publish-publisher">
-                        {t('publishBook.fields.publisher')}
-                      </label>
-                      <input
-                        id="publish-publisher"
-                        className={styles.input}
-                        value={state.metadata.publisher}
-                        onChange={(event) =>
-                          updateMetadata({ publisher: event.target.value })
-                        }
-                        onBlur={handleBlur}
-                      />
-                    </div>
-                    <div className={styles.formGroup}>
-                      <label htmlFor="publish-year">
-                        {t('publishBook.fields.year')}
-                      </label>
-                      <input
-                        id="publish-year"
-                        className={styles.input}
-                        value={state.metadata.year}
-                        onChange={(event) =>
-                          updateMetadata({ year: event.target.value })
-                        }
-                        onBlur={handleBlur}
-                        inputMode="numeric"
-                      />
-                    </div>
-                    <div className={styles.formGroup}>
-                      <label htmlFor="publish-isbn">
-                        {t('publishBook.fields.isbn')}
-                      </label>
-                      <input
-                        id="publish-isbn"
-                        className={styles.input}
-                        value={state.metadata.isbn}
-                        onChange={(event) =>
-                          updateMetadata({ isbn: event.target.value })
-                        }
-                        onBlur={handleBlur}
-                      />
-                    </div>
-                  </div>
-
-                  <div>
-                    <div className={styles.formGroup}>
-                      <label>{t('publishBook.fields.images')}</label>
-                      <div
-                        className={styles.uploader}
-                        role="group"
-                        onDragOver={(event) => {
-                          event.preventDefault()
-                          event.stopPropagation()
-                        }}
-                        onDrop={(event) => {
-                          event.preventDefault()
-                          handleFiles(event.dataTransfer.files)
-                        }}
-                      >
-                        <p>{t('publishBook.uploader.title')}</p>
-                        <span className={styles.uploadHint}>
-                          {t('publishBook.uploader.hint', {
-                            count: MAX_IMAGES_UPLOAD,
-                          })}
-                        </span>
-                        <label
-                          className={styles.uploadButton}
-                          htmlFor="publish-upload"
-                        >
-                          {t('publishBook.uploader.cta')}
-                        </label>
-                        <input
-                          id="publish-upload"
-                          type="file"
-                          accept="image/*"
-                          multiple
-                          onChange={(event) => handleFiles(event.target.files)}
-                        />
-                      </div>
-                      {identifyErrors.images && (
-                        <span className={styles.error} role="alert">
-                          {identifyErrors.images}
-                        </span>
-                      )}
-                    </div>
-                    {imagesCount > 0 && (
-                      <div className={styles.previews}>
-                        {state.images.map((image) => (
-                          <figure key={image.id} className={styles.previewItem}>
-                            <img
-                              src={image.url}
-                              alt={t('publishBook.previewAlt')}
-                            />
-                            <button
-                              type="button"
-                              className={styles.removePreview}
-                              onClick={() => removeImage(image.id)}
-                              aria-label={
-                                t('publishBook.uploader.remove') ?? ''
-                              }
-                            >
-                              ×
-                            </button>
-                          </figure>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
+                <IdentifyStep
+                  t={t}
+                  metadata={state.metadata}
+                  manualMode={state.manualMode}
+                  searchQuery={state.searchQuery}
+                  images={state.images}
+                  errors={identifyErrors}
+                  results={results}
+                  isFetching={isFetching}
+                  isError={isError}
+                  maxImages={MAX_IMAGES_UPLOAD}
+                  onMetadataChange={updateMetadata}
+                  onSearchChange={handleSearchChange}
+                  onManualModeToggle={handleManualModeToggle}
+                  onResultSelect={handleResult}
+                  onFiles={handleFiles}
+                  onRemoveImage={removeImage}
+                  onRetry={handleRetrySearch}
+                  onBlur={handleBlur}
+                />
               )}
 
               {state.step === 'offer' && (
-                <div className={styles.stepLayout}>
-                  <div className={styles.formGroup}>
-                    <label>{t('publishBook.offer.modes.label')}</label>
-                    <div className={styles.checkboxGroup}>
-                      {(['trade', 'sale', 'donation'] as const).map((mode) => (
-                        <label key={mode} className={styles.checkboxRow}>
-                          <input
-                            type="checkbox"
-                            checked={state.offer[mode]}
-                            onChange={(event) =>
-                              updateOffer({ [mode]: event.target.checked })
-                            }
-                          />
-                          <span>{t(`publishBook.offer.modes.${mode}`)}</span>
-                        </label>
-                      ))}
-                    </div>
-                    {offerErrors.modes && (
-                      <span className={styles.error} role="alert">
-                        {offerErrors.modes}
-                      </span>
-                    )}
-                  </div>
-
-                  <div className={styles.formGroup}>
-                    <label>{t('publishBook.offer.condition.label')}</label>
-                    <div className={styles.radioGroup}>
-                      {(
-                        ['new', 'very_good', 'good', 'acceptable'] as const
-                      ).map((condition) => (
-                        <label key={condition} className={styles.radioRow}>
-                          <input
-                            type="radio"
-                            name="publish-condition"
-                            value={condition}
-                            checked={state.offer.condition === condition}
-                            onChange={() => updateOffer({ condition })}
-                          />
-                          <span>
-                            {t(
-                              `publishBook.offer.condition.options.${condition}`
-                            )}
-                          </span>
-                        </label>
-                      ))}
-                    </div>
-                    {offerErrors.condition && (
-                      <span className={styles.error} role="alert">
-                        {offerErrors.condition}
-                      </span>
-                    )}
-                  </div>
-
-                  {state.offer.sale && (
-                    <div className={styles.priceGrid}>
-                      <div className={styles.formGroup}>
-                        <label htmlFor="publish-price">
-                          {t('publishBook.offer.price.label')}
-                        </label>
-                        <input
-                          id="publish-price"
-                          className={styles.input}
-                          inputMode="decimal"
-                          value={state.offer.priceAmount}
-                          onChange={(event) =>
-                            updateOffer({ priceAmount: event.target.value })
-                          }
-                          onBlur={handleBlur}
-                          aria-invalid={offerErrors.price ? 'true' : 'false'}
-                        />
-                        {offerErrors.price && (
-                          <span className={styles.error} role="alert">
-                            {offerErrors.price}
-                          </span>
-                        )}
-                      </div>
-                      <div className={styles.formGroup}>
-                        <label htmlFor="publish-currency">
-                          {t('publishBook.offer.price.currency')}
-                        </label>
-                        <select
-                          id="publish-currency"
-                          className={styles.select}
-                          value={state.offer.priceCurrency}
-                          onChange={(event) =>
-                            updateOffer({ priceCurrency: event.target.value })
-                          }
-                        >
-                          <option value="ARS">ARS</option>
-                          <option value="USD">USD</option>
-                          <option value="EUR">EUR</option>
-                        </select>
-                      </div>
-                    </div>
-                  )}
-
-                  {state.offer.trade && (
-                    <div className={styles.formGroup}>
-                      <label>{t('publishBook.offer.trade.label')}</label>
-                      <div className={styles.badgeRow}>
-                        {genres.map((genre) => {
-                          const isActive =
-                            state.offer.tradePreferences.includes(genre)
-                          return (
-                            <button
-                              key={genre}
-                              type="button"
-                              className={`${styles.badge} ${
-                                isActive ? styles.badgeActive : ''
-                              }`.trim()}
-                              onClick={() => {
-                                setState((prev) => {
-                                  const tradePreferences = isActive
-                                    ? prev.offer.tradePreferences.filter(
-                                        (item) => item !== genre
-                                      )
-                                    : [...prev.offer.tradePreferences, genre]
-                                  return {
-                                    ...prev,
-                                    offer: { ...prev.offer, tradePreferences },
-                                  }
-                                })
-                              }}
-                            >
-                              {t(`publishBook.offer.trade.genres.${genre}`)}
-                            </button>
-                          )
-                        })}
-                      </div>
-                    </div>
-                  )}
-
-                  <div className={styles.formGroup}>
-                    <label htmlFor="publish-notes">
-                      {t('publishBook.offer.notes.label')}
-                    </label>
-                    <textarea
-                      id="publish-notes"
-                      className={styles.textarea}
-                      value={state.offer.notes}
-                      maxLength={300}
-                      onChange={(event) =>
-                        updateOffer({ notes: event.target.value })
-                      }
-                      onBlur={handleBlur}
-                    />
-                    <span className={styles.toastInline}>
-                      {t('publishBook.offer.notes.counter', {
-                        count: state.offer.notes.length,
-                      })}
-                    </span>
-                  </div>
-
-                  <div className={styles.formGroup}>
-                    <label>{t('publishBook.offer.availability.label')}</label>
-                    <div className={styles.radioGroup}>
-                      {(['public', 'private'] as const).map((mode) => (
-                        <label key={mode} className={styles.radioRow}>
-                          <input
-                            type="radio"
-                            name="publish-availability"
-                            value={mode}
-                            checked={state.offer.availability === mode}
-                            onChange={() => updateOffer({ availability: mode })}
-                          />
-                          <span>
-                            {t(
-                              `publishBook.offer.availability.options.${mode}`
-                            )}
-                          </span>
-                        </label>
-                      ))}
-                    </div>
-                  </div>
-
-                  <div className={styles.formGroup}>
-                    <label>{t('publishBook.offer.delivery.label')}</label>
-                    <div className={styles.checkboxGroup}>
-                      <label className={styles.checkboxRow}>
-                        <input
-                          type="checkbox"
-                          checked={state.offer.delivery.nearBookCorner}
-                          onChange={(event) =>
-                            updateDelivery({
-                              nearBookCorner: event.target.checked,
-                            })
-                          }
-                        />
-                        <span>
-                          {t(
-                            'publishBook.offer.delivery.options.nearBookCorner'
-                          )}
-                        </span>
-                      </label>
-                      <label className={styles.checkboxRow}>
-                        <input
-                          type="checkbox"
-                          checked={state.offer.delivery.inPerson}
-                          onChange={(event) =>
-                            updateDelivery({ inPerson: event.target.checked })
-                          }
-                        />
-                        <span>
-                          {t('publishBook.offer.delivery.options.inPerson')}
-                        </span>
-                      </label>
-                      <label className={styles.checkboxRow}>
-                        <input
-                          type="checkbox"
-                          checked={state.offer.delivery.shipping}
-                          onChange={(event) =>
-                            updateDelivery({ shipping: event.target.checked })
-                          }
-                        />
-                        <span>
-                          {t('publishBook.offer.delivery.options.shipping')}
-                        </span>
-                      </label>
-                    </div>
-                    {state.offer.delivery.shipping && (
-                      <div className={styles.formGroup}>
-                        <label htmlFor="publish-shipping-payer">
-                          {t('publishBook.offer.delivery.shippingPayer.label')}
-                        </label>
-                        <select
-                          id="publish-shipping-payer"
-                          className={styles.select}
-                          value={state.offer.delivery.shippingPayer}
-                          onChange={(event) =>
-                            updateDelivery({
-                              shippingPayer: event.target
-                                .value as PublishBookOffer['delivery']['shippingPayer'],
-                            })
-                          }
-                          onBlur={handleBlur}
-                        >
-                          <option value="owner">
-                            {t(
-                              'publishBook.offer.delivery.shippingPayer.owner'
-                            )}
-                          </option>
-                          <option value="requester">
-                            {t(
-                              'publishBook.offer.delivery.shippingPayer.requester'
-                            )}
-                          </option>
-                          <option value="split">
-                            {t(
-                              'publishBook.offer.delivery.shippingPayer.split'
-                            )}
-                          </option>
-                        </select>
-                      </div>
-                    )}
-                  </div>
-                </div>
+                <OfferStep
+                  t={t}
+                  offer={state.offer}
+                  errors={offerErrors}
+                  genres={genres}
+                  onOfferChange={updateOffer}
+                  onDeliveryChange={updateDelivery}
+                  onToggleTradePreference={toggleTradePreference}
+                  onBlur={handleBlur}
+                />
               )}
 
               {state.step === 'review' && (
-                <div className={styles.stepLayout}>
-                  <div className={styles.reviewCardWrapper}>
-                    <BookCard
-                      title={state.metadata.title}
-                      author={state.metadata.author}
-                      coverUrl={coverUrl}
-                      condition={t(
-                        `publishBook.preview.condition.${state.offer.condition}`
-                      )}
-                      status="available"
-                      isForSale={state.offer.sale}
-                      price={
-                        state.offer.sale
-                          ? Number(state.offer.priceAmount)
-                          : undefined
-                      }
-                      isForTrade={state.offer.trade}
-                      tradePreferences={state.offer.tradePreferences.map(
-                        (genre) => t(`publishBook.offer.trade.genres.${genre}`)
-                      )}
-                      isSeeking={false}
-                    />
-                  </div>
-
-                  <div className={styles.checklist}>
-                    <label className={styles.checklistItem}>
-                      <input
-                        type="checkbox"
-                        checked={state.acceptedTerms}
-                        onChange={(event) =>
-                          setState((prev) => ({
-                            ...prev,
-                            acceptedTerms: event.target.checked,
-                          }))
-                        }
-                      />
-                      <span>{t('publishBook.review.terms')}</span>
-                    </label>
-                    <p className={styles.toastInline}>
-                      {t('publishBook.review.hint')}
-                    </p>
-                  </div>
-                </div>
+                <ReviewStep
+                  t={t}
+                  metadata={state.metadata}
+                  offer={state.offer}
+                  coverUrl={coverUrl}
+                  acceptedTerms={state.acceptedTerms}
+                  onAcceptedTermsChange={handleAcceptedTermsChange}
+                />
               )}
             </div>
           </section>
@@ -1173,7 +602,7 @@ export const PublishBookModal: React.FC<PublishBookModalProps> = ({
               <button
                 type="button"
                 className={styles.secondaryButton}
-                onClick={saveDraft}
+                onClick={handleSaveDraft}
               >
                 {t('publishBook.saveDraft')}
               </button>

--- a/frontend/src/components/publish/PublishBookModal/PublishBookModal.utils.ts
+++ b/frontend/src/components/publish/PublishBookModal/PublishBookModal.utils.ts
@@ -1,0 +1,48 @@
+import {
+  initialMetadata,
+  initialOffer,
+  initialState,
+} from './PublishBookModal.constants'
+import {
+  PublishBookDraftState,
+  PublishBookFormState,
+  PublishBookImage,
+} from './PublishBookModal.types'
+
+export const sanitizeDraft = (
+  draft: PublishBookDraftState | null
+): PublishBookFormState => {
+  if (!draft) return initialState
+  return {
+    ...initialState,
+    ...draft,
+    metadata: { ...initialMetadata, ...draft.metadata },
+    offer: { ...initialOffer, ...draft.offer },
+  }
+}
+
+export const ensureCover = (
+  images: PublishBookImage[],
+  coverUrl?: string
+): PublishBookImage[] => {
+  if (coverUrl && !images.some((image) => image.source === 'cover')) {
+    return [
+      {
+        id: `cover-${Date.now()}`,
+        url: coverUrl,
+        source: 'cover',
+      },
+      ...images,
+    ]
+  }
+  return images
+}
+
+export const getPreviewCover = (
+  images: PublishBookImage[],
+  fallback?: string
+): string => {
+  if (images.length === 0) return fallback ?? ''
+  const cover = images.find((image) => image.source === 'cover')
+  return (cover ?? images[0]).url
+}

--- a/frontend/src/components/publish/PublishBookModal/components/IdentifyStep.tsx
+++ b/frontend/src/components/publish/PublishBookModal/components/IdentifyStep.tsx
@@ -1,0 +1,334 @@
+import { TFunction } from 'i18next'
+import React from 'react'
+
+import { ApiBookSearchResult } from '@src/api/books/searchBooks.types'
+
+import styles from '../PublishBookModal.module.scss'
+import {
+  PublishBookImage,
+  PublishBookMetadata,
+} from '../PublishBookModal.types'
+
+type IdentifyStepErrors = Partial<
+  Record<'title' | 'author' | 'language' | 'format' | 'images', string>
+>
+
+type IdentifyStepProps = {
+  t: TFunction
+  metadata: PublishBookMetadata
+  manualMode: boolean
+  searchQuery: string
+  images: PublishBookImage[]
+  errors: IdentifyStepErrors
+  results?: ApiBookSearchResult[]
+  isFetching: boolean
+  isError: boolean
+  maxImages: number
+  onMetadataChange: (update: Partial<PublishBookMetadata>) => void
+  onSearchChange: (value: string) => void
+  onManualModeToggle: (checked: boolean) => void
+  onResultSelect: (result: ApiBookSearchResult) => void
+  onFiles: (files: FileList | null) => void
+  onRemoveImage: (id: string) => void
+  onRetry: () => void
+  onBlur: React.FocusEventHandler<HTMLElement>
+}
+
+export const IdentifyStep: React.FC<IdentifyStepProps> = React.memo(
+  ({
+    t,
+    metadata,
+    manualMode,
+    searchQuery,
+    images,
+    errors,
+    results,
+    isFetching,
+    isError,
+    maxImages,
+    onMetadataChange,
+    onSearchChange,
+    onManualModeToggle,
+    onResultSelect,
+    onFiles,
+    onRemoveImage,
+    onRetry,
+    onBlur,
+  }) => {
+    const imagesCount = images.length
+
+    return (
+      <div className={styles.stepLayout}>
+        <div>
+          <div className={styles.formGroup}>
+            <label htmlFor="publish-search">
+              {t('publishBook.search.label')}
+            </label>
+            <input
+              id="publish-search"
+              type="search"
+              className={styles.input}
+              placeholder={t('publishBook.search.placeholder') ?? ''}
+              value={searchQuery}
+              onChange={(event) => onSearchChange(event.target.value)}
+              onBlur={onBlur}
+            />
+          </div>
+          {isFetching && (
+            <div className={styles.loadingRow} role="status">
+              <span className={styles.spinner} aria-hidden />
+              <span>{t('publishBook.search.loading')}</span>
+            </div>
+          )}
+          {isError && (
+            <div className={styles.error} role="alert">
+              {t('publishBook.search.error')}{' '}
+              <button
+                type="button"
+                className={styles.ghostButton}
+                onClick={onRetry}
+              >
+                {t('publishBook.search.retry')}
+              </button>
+            </div>
+          )}
+          {results && results.length === 0 && (
+            <p className={styles.toastInline}>
+              {t('publishBook.search.empty')}
+            </p>
+          )}
+          {results && results.length > 0 && (
+            <div className={styles.searchResults}>
+              {results.map((book) => (
+                <div key={book.id} className={styles.searchResult}>
+                  {book.coverUrl ? (
+                    <img
+                      src={book.coverUrl}
+                      alt={t('publishBook.search.cover', {
+                        title: book.title,
+                      })}
+                      className={styles.searchCover}
+                    />
+                  ) : (
+                    <div className={styles.searchCover} aria-hidden="true" />
+                  )}
+                  <div className={styles.searchMeta}>
+                    <strong>{book.title}</strong>
+                    <span>
+                      {book.author}
+                      {book.year ? ` · ${book.year}` : ''}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    className={styles.searchButton}
+                    onClick={() => onResultSelect(book)}
+                  >
+                    {t('publishBook.search.use')}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className={styles.manualToggle}>
+            <input
+              type="checkbox"
+              id="publish-manual"
+              checked={manualMode}
+              onChange={(event) => onManualModeToggle(event.target.checked)}
+            />
+            <label htmlFor="publish-manual" className={styles.switchLabel}>
+              {t('publishBook.manualToggle')}
+            </label>
+          </div>
+        </div>
+
+        <div className={styles.formGrid}>
+          <div className={styles.formGroup}>
+            <label htmlFor="publish-title">
+              {t('publishBook.fields.title')}
+            </label>
+            <input
+              id="publish-title"
+              className={styles.input}
+              value={metadata.title}
+              onChange={(event) =>
+                onMetadataChange({ title: event.target.value })
+              }
+              onBlur={onBlur}
+              required
+              aria-invalid={errors.title ? 'true' : 'false'}
+            />
+            {errors.title && (
+              <span className={styles.error} role="alert">
+                {errors.title}
+              </span>
+            )}
+          </div>
+          <div className={styles.formGroup}>
+            <label htmlFor="publish-author">
+              {t('publishBook.fields.author')}
+            </label>
+            <input
+              id="publish-author"
+              className={styles.input}
+              value={metadata.author}
+              onChange={(event) =>
+                onMetadataChange({ author: event.target.value })
+              }
+              onBlur={onBlur}
+              required
+              aria-invalid={errors.author ? 'true' : 'false'}
+            />
+            {errors.author && (
+              <span className={styles.error} role="alert">
+                {errors.author}
+              </span>
+            )}
+          </div>
+          <div className={styles.formGroup}>
+            <label htmlFor="publish-language">
+              {t('publishBook.fields.language')}
+            </label>
+            <input
+              id="publish-language"
+              className={styles.input}
+              value={metadata.language}
+              onChange={(event) =>
+                onMetadataChange({ language: event.target.value })
+              }
+              onBlur={onBlur}
+              required
+              aria-invalid={errors.language ? 'true' : 'false'}
+            />
+            {errors.language && (
+              <span className={styles.error} role="alert">
+                {errors.language}
+              </span>
+            )}
+          </div>
+          <div className={styles.formGroup}>
+            <label htmlFor="publish-format">
+              {t('publishBook.fields.format')}
+            </label>
+            <input
+              id="publish-format"
+              className={styles.input}
+              value={metadata.format}
+              onChange={(event) =>
+                onMetadataChange({ format: event.target.value })
+              }
+              onBlur={onBlur}
+              required
+              aria-invalid={errors.format ? 'true' : 'false'}
+            />
+            {errors.format && (
+              <span className={styles.error} role="alert">
+                {errors.format}
+              </span>
+            )}
+          </div>
+          <div className={styles.formGroup}>
+            <label htmlFor="publish-publisher">
+              {t('publishBook.fields.publisher')}
+            </label>
+            <input
+              id="publish-publisher"
+              className={styles.input}
+              value={metadata.publisher}
+              onChange={(event) =>
+                onMetadataChange({ publisher: event.target.value })
+              }
+              onBlur={onBlur}
+            />
+          </div>
+          <div className={styles.formGroup}>
+            <label htmlFor="publish-year">{t('publishBook.fields.year')}</label>
+            <input
+              id="publish-year"
+              className={styles.input}
+              value={metadata.year}
+              onChange={(event) =>
+                onMetadataChange({ year: event.target.value })
+              }
+              onBlur={onBlur}
+              inputMode="numeric"
+            />
+          </div>
+          <div className={styles.formGroup}>
+            <label htmlFor="publish-isbn">{t('publishBook.fields.isbn')}</label>
+            <input
+              id="publish-isbn"
+              className={styles.input}
+              value={metadata.isbn}
+              onChange={(event) =>
+                onMetadataChange({ isbn: event.target.value })
+              }
+              onBlur={onBlur}
+            />
+          </div>
+        </div>
+
+        <div>
+          <div className={styles.formGroup}>
+            <label>{t('publishBook.fields.images')}</label>
+            <div
+              className={styles.uploader}
+              role="group"
+              onDragOver={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+              }}
+              onDrop={(event) => {
+                event.preventDefault()
+                onFiles(event.dataTransfer.files)
+              }}
+            >
+              <p>{t('publishBook.uploader.title')}</p>
+              <span className={styles.uploadHint}>
+                {t('publishBook.uploader.hint', {
+                  count: maxImages,
+                })}
+              </span>
+              <label className={styles.uploadButton} htmlFor="publish-upload">
+                {t('publishBook.uploader.cta')}
+              </label>
+              <input
+                id="publish-upload"
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={(event) => onFiles(event.target.files)}
+              />
+            </div>
+            {errors.images && (
+              <span className={styles.error} role="alert">
+                {errors.images}
+              </span>
+            )}
+          </div>
+          {imagesCount > 0 && (
+            <div className={styles.previews}>
+              {images.map((image) => (
+                <figure key={image.id} className={styles.previewItem}>
+                  <img src={image.url} alt={t('publishBook.previewAlt')} />
+                  <button
+                    type="button"
+                    className={styles.removePreview}
+                    onClick={() => onRemoveImage(image.id)}
+                    aria-label={t('publishBook.uploader.remove') ?? ''}
+                  >
+                    ×
+                  </button>
+                </figure>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+)
+
+IdentifyStep.displayName = 'IdentifyStep'

--- a/frontend/src/components/publish/PublishBookModal/components/OfferStep.tsx
+++ b/frontend/src/components/publish/PublishBookModal/components/OfferStep.tsx
@@ -1,0 +1,258 @@
+import { TFunction } from 'i18next'
+import React from 'react'
+
+import styles from '../PublishBookModal.module.scss'
+import { PublishBookOffer } from '../PublishBookModal.types'
+
+type OfferStepErrors = Partial<Record<'modes' | 'condition' | 'price', string>>
+
+type OfferStepProps = {
+  t: TFunction
+  offer: PublishBookOffer
+  errors: OfferStepErrors
+  genres: readonly PublishBookOffer['tradePreferences'][number][]
+  onOfferChange: (update: Partial<PublishBookOffer>) => void
+  onDeliveryChange: (update: Partial<PublishBookOffer['delivery']>) => void
+  onToggleTradePreference: (
+    genre: PublishBookOffer['tradePreferences'][number]
+  ) => void
+  onBlur: React.FocusEventHandler<HTMLElement>
+}
+
+export const OfferStep: React.FC<OfferStepProps> = React.memo(
+  ({
+    t,
+    offer,
+    errors,
+    genres,
+    onOfferChange,
+    onDeliveryChange,
+    onToggleTradePreference,
+    onBlur,
+  }) => (
+    <div className={styles.stepLayout}>
+      <div className={styles.formGroup}>
+        <label>{t('publishBook.offer.modes.label')}</label>
+        <div className={styles.checkboxGroup}>
+          {(['trade', 'sale', 'donation'] as const).map((mode) => (
+            <label key={mode} className={styles.checkboxRow}>
+              <input
+                type="checkbox"
+                checked={offer[mode]}
+                onChange={(event) =>
+                  onOfferChange({ [mode]: event.target.checked })
+                }
+              />
+              <span>{t(`publishBook.offer.modes.${mode}`)}</span>
+            </label>
+          ))}
+        </div>
+        {errors.modes && (
+          <span className={styles.error} role="alert">
+            {errors.modes}
+          </span>
+        )}
+      </div>
+
+      <div className={styles.formGroup}>
+        <label>{t('publishBook.offer.condition.label')}</label>
+        <div className={styles.radioGroup}>
+          {(['new', 'very_good', 'good', 'acceptable'] as const).map(
+            (condition) => (
+              <label key={condition} className={styles.radioRow}>
+                <input
+                  type="radio"
+                  name="publish-condition"
+                  value={condition}
+                  checked={offer.condition === condition}
+                  onChange={() => onOfferChange({ condition })}
+                />
+                <span>
+                  {t(`publishBook.offer.condition.options.${condition}`)}
+                </span>
+              </label>
+            )
+          )}
+        </div>
+        {errors.condition && (
+          <span className={styles.error} role="alert">
+            {errors.condition}
+          </span>
+        )}
+      </div>
+
+      {offer.sale && (
+        <div className={styles.priceGrid}>
+          <div className={styles.formGroup}>
+            <label htmlFor="publish-price">
+              {t('publishBook.offer.price.label')}
+            </label>
+            <input
+              id="publish-price"
+              className={styles.input}
+              inputMode="decimal"
+              value={offer.priceAmount}
+              onChange={(event) =>
+                onOfferChange({ priceAmount: event.target.value })
+              }
+              onBlur={onBlur}
+              aria-invalid={errors.price ? 'true' : 'false'}
+            />
+            {errors.price && (
+              <span className={styles.error} role="alert">
+                {errors.price}
+              </span>
+            )}
+          </div>
+          <div className={styles.formGroup}>
+            <label htmlFor="publish-currency">
+              {t('publishBook.offer.price.currency')}
+            </label>
+            <select
+              id="publish-currency"
+              className={styles.select}
+              value={offer.priceCurrency}
+              onChange={(event) =>
+                onOfferChange({ priceCurrency: event.target.value })
+              }
+            >
+              <option value="ARS">ARS</option>
+              <option value="USD">USD</option>
+              <option value="EUR">EUR</option>
+            </select>
+          </div>
+        </div>
+      )}
+
+      {offer.trade && (
+        <div className={styles.formGroup}>
+          <label>{t('publishBook.offer.trade.label')}</label>
+          <div className={styles.badgeRow}>
+            {genres.map((genre) => {
+              const isActive = offer.tradePreferences.includes(genre)
+              return (
+                <button
+                  key={genre}
+                  type="button"
+                  className={`${styles.badge} ${
+                    isActive ? styles.badgeActive : ''
+                  }`.trim()}
+                  onClick={() => onToggleTradePreference(genre)}
+                >
+                  {t(`publishBook.offer.trade.genres.${genre}`)}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className={styles.formGroup}>
+        <label htmlFor="publish-notes">
+          {t('publishBook.offer.notes.label')}
+        </label>
+        <textarea
+          id="publish-notes"
+          className={styles.textarea}
+          value={offer.notes}
+          maxLength={300}
+          onChange={(event) => onOfferChange({ notes: event.target.value })}
+          onBlur={onBlur}
+        />
+        <span className={styles.toastInline}>
+          {t('publishBook.offer.notes.counter', {
+            count: offer.notes.length,
+          })}
+        </span>
+      </div>
+
+      <div className={styles.formGroup}>
+        <label>{t('publishBook.offer.availability.label')}</label>
+        <div className={styles.radioGroup}>
+          {(['public', 'private'] as const).map((mode) => (
+            <label key={mode} className={styles.radioRow}>
+              <input
+                type="radio"
+                name="publish-availability"
+                value={mode}
+                checked={offer.availability === mode}
+                onChange={() => onOfferChange({ availability: mode })}
+              />
+              <span>{t(`publishBook.offer.availability.options.${mode}`)}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.formGroup}>
+        <label>{t('publishBook.offer.delivery.label')}</label>
+        <div className={styles.checkboxGroup}>
+          <label className={styles.checkboxRow}>
+            <input
+              type="checkbox"
+              checked={offer.delivery.nearBookCorner}
+              onChange={(event) =>
+                onDeliveryChange({ nearBookCorner: event.target.checked })
+              }
+            />
+            <span>
+              {t('publishBook.offer.delivery.options.nearBookCorner')}
+            </span>
+          </label>
+          <label className={styles.checkboxRow}>
+            <input
+              type="checkbox"
+              checked={offer.delivery.inPerson}
+              onChange={(event) =>
+                onDeliveryChange({ inPerson: event.target.checked })
+              }
+            />
+            <span>{t('publishBook.offer.delivery.options.inPerson')}</span>
+          </label>
+          <label className={styles.checkboxRow}>
+            <input
+              type="checkbox"
+              checked={offer.delivery.shipping}
+              onChange={(event) =>
+                onDeliveryChange({ shipping: event.target.checked })
+              }
+            />
+            <span>{t('publishBook.offer.delivery.options.shipping')}</span>
+          </label>
+        </div>
+      </div>
+
+      {offer.delivery.shipping && (
+        <div className={styles.formGroup}>
+          <label htmlFor="publish-shipping-payer">
+            {t('publishBook.offer.delivery.shippingPayer.label')}
+          </label>
+          <select
+            id="publish-shipping-payer"
+            className={styles.select}
+            value={offer.delivery.shippingPayer}
+            onChange={(event) =>
+              onDeliveryChange({
+                shippingPayer: event.target
+                  .value as PublishBookOffer['delivery']['shippingPayer'],
+              })
+            }
+            onBlur={onBlur}
+          >
+            <option value="owner">
+              {t('publishBook.offer.delivery.shippingPayer.owner')}
+            </option>
+            <option value="requester">
+              {t('publishBook.offer.delivery.shippingPayer.requester')}
+            </option>
+            <option value="split">
+              {t('publishBook.offer.delivery.shippingPayer.split')}
+            </option>
+          </select>
+        </div>
+      )}
+    </div>
+  )
+)
+
+OfferStep.displayName = 'OfferStep'

--- a/frontend/src/components/publish/PublishBookModal/components/PublishBookStepper.tsx
+++ b/frontend/src/components/publish/PublishBookModal/components/PublishBookStepper.tsx
@@ -1,0 +1,45 @@
+import { TFunction } from 'i18next'
+import React from 'react'
+
+import styles from '../PublishBookModal.module.scss'
+import { PublishBookStep } from '../PublishBookModal.types'
+
+type PublishBookStepperProps = {
+  currentStep: PublishBookStep
+  t: TFunction
+  stepOrder: PublishBookStep[]
+  stepIndex: Record<PublishBookStep, number>
+}
+
+export const PublishBookStepper: React.FC<PublishBookStepperProps> = React.memo(
+  ({ currentStep, t, stepOrder, stepIndex }) => (
+    <div
+      className={styles.stepper}
+      role="tablist"
+      aria-label={t('publishBook.progress')}
+    >
+      {stepOrder.map((step) => (
+        <div key={step} className={styles.step}>
+          <span
+            className={`${styles.stepIndicator} ${
+              step === currentStep ? styles.stepActive : ''
+            }`.trim()}
+            aria-hidden="true"
+          >
+            {stepIndex[step] + 1}
+          </span>
+          <div>
+            <div className={styles.stepLabel}>
+              {t(`publishBook.steps.${step}.title`)}
+            </div>
+            <div className={styles.stepDescription}>
+              {t(`publishBook.steps.${step}.description`)}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+)
+
+PublishBookStepper.displayName = 'PublishBookStepper'

--- a/frontend/src/components/publish/PublishBookModal/components/ResumeDraftPrompt.tsx
+++ b/frontend/src/components/publish/PublishBookModal/components/ResumeDraftPrompt.tsx
@@ -1,0 +1,37 @@
+import { TFunction } from 'i18next'
+import React from 'react'
+
+import styles from '../PublishBookModal.module.scss'
+
+type ResumeDraftPromptProps = {
+  t: TFunction
+  onDiscard: () => void
+  onResume: () => void
+}
+
+export const ResumeDraftPrompt: React.FC<ResumeDraftPromptProps> = React.memo(
+  ({ t, onDiscard, onResume }) => (
+    <div className={styles.resumePrompt} role="dialog" aria-modal="true">
+      <h2>{t('publishBook.resume.title')}</h2>
+      <p>{t('publishBook.resume.description')}</p>
+      <div className={styles.resumeActions}>
+        <button
+          type="button"
+          className={styles.secondaryButton}
+          onClick={onDiscard}
+        >
+          {t('publishBook.resume.discard')}
+        </button>
+        <button
+          type="button"
+          className={styles.primaryButton}
+          onClick={onResume}
+        >
+          {t('publishBook.resume.continue')}
+        </button>
+      </div>
+    </div>
+  )
+)
+
+ResumeDraftPrompt.displayName = 'ResumeDraftPrompt'

--- a/frontend/src/components/publish/PublishBookModal/components/ReviewStep.tsx
+++ b/frontend/src/components/publish/PublishBookModal/components/ReviewStep.tsx
@@ -1,0 +1,52 @@
+import { BookCard } from '@components/book/BookCard'
+import { TFunction } from 'i18next'
+import React from 'react'
+
+import styles from '../PublishBookModal.module.scss'
+import { PublishBookFormState } from '../PublishBookModal.types'
+
+type ReviewStepProps = {
+  t: TFunction
+  metadata: PublishBookFormState['metadata']
+  offer: PublishBookFormState['offer']
+  coverUrl: string
+  acceptedTerms: boolean
+  onAcceptedTermsChange: (checked: boolean) => void
+}
+
+export const ReviewStep: React.FC<ReviewStepProps> = React.memo(
+  ({ t, metadata, offer, coverUrl, acceptedTerms, onAcceptedTermsChange }) => (
+    <div className={styles.stepLayout}>
+      <div className={styles.reviewCardWrapper}>
+        <BookCard
+          title={metadata.title}
+          author={metadata.author}
+          coverUrl={coverUrl}
+          condition={t(`publishBook.preview.condition.${offer.condition}`)}
+          status="available"
+          isForSale={offer.sale}
+          price={offer.sale ? Number(offer.priceAmount) : undefined}
+          isForTrade={offer.trade}
+          tradePreferences={offer.tradePreferences.map((genre) =>
+            t(`publishBook.offer.trade.genres.${genre}`)
+          )}
+          isSeeking={false}
+        />
+      </div>
+
+      <div className={styles.checklist}>
+        <label className={styles.checklistItem}>
+          <input
+            type="checkbox"
+            checked={acceptedTerms}
+            onChange={(event) => onAcceptedTermsChange(event.target.checked)}
+          />
+          <span>{t('publishBook.review.terms')}</span>
+        </label>
+        <p className={styles.toastInline}>{t('publishBook.review.hint')}</p>
+      </div>
+    </div>
+  )
+)
+
+ReviewStep.displayName = 'ReviewStep'

--- a/frontend/src/components/publish/PublishBookModal/useDebouncedValue.ts
+++ b/frontend/src/components/publish/PublishBookModal/useDebouncedValue.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+
+export const useDebouncedValue = (value: string, delay = 400) => {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebounced(value), delay)
+    return () => window.clearTimeout(timeout)
+  }, [value, delay])
+
+  return debounced
+}


### PR DESCRIPTION
## Summary
- extract publish modal defaults and helpers into dedicated modules and add a JSON-based draft comparator
- split the publish modal UI into memoized subcomponents for identify, offer, review, stepper, and draft resume prompt
- add a reusable debounced value hook and update the product backlog with the refactor status

## Testing
- `npm run test:frontend`
- `npm run test:backend`
- `npm run format:backend`
- `npm run format:frontend`