### PR TITLE
feat: add editable book detail modal

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -96,6 +96,7 @@ Feature 3.1 Publicación y calidad del dato
   - Actualización 2025-10-08: se refactorizó el modal en componentes reutilizables, optimizando renders y mantenimiento sin alterar el flujo funcional.
   - Actualización 2025-10-08 (backend): se documentó en `docs/base_de_datos.md` la brecha entre el flujo del frontend y el modelo real (solo `users`/`books`). TODO: migraciones para `publications`, endpoints `/books/mine`, `/books/:id` y soporte de imágenes.
   - Actualización 2025-10-30: se agregó persistencia real de publicaciones (tabla `publications` + `publication_images`), endpoints `/api/books` y `/api/books/mine`, validaciones de oferta/entrega y pruebas end-to-end para publicar y listar ejemplares propios.
+  - Actualización 2025-10-31: el frontend ahora permite consultar y editar publicaciones existentes en un modal accesible, con datos en vivo vía hooks de React Query, actualización optimista, validaciones básicas y handlers MSW (GET/PUT) para garantizar coherencia mock/backend.
 - [~] S-3.2 Normalización asistida por ISBN/metadata (Should, E2; BR-22)
   - Éxito: autocompletado; reducción de duplicados/ambigüedades.
 - [ ] S-3.3 Contenidos permitidos/denegados (política editorial) (Must, E1; BR-24)

--- a/frontend/mocks/handlers/books/bookDetail.handler.ts
+++ b/frontend/mocks/handlers/books/bookDetail.handler.ts
@@ -1,0 +1,87 @@
+import { http, HttpResponse } from 'msw'
+
+import { RELATIVE_API_ROUTES } from '@src/api/routes'
+
+import { publicationStore } from './fakers/publications.faker'
+import type { PublicationUpdate } from '@src/api/books/publication.types'
+
+const BOOK_DETAIL_ROUTE = RELATIVE_API_ROUTES.BOOKS.DETAIL(':id')
+
+export const bookDetailHandler = http.get(
+  BOOK_DETAIL_ROUTE,
+  async ({ params }) => {
+    const id = params.id
+    if (typeof id !== 'string' || !id) {
+      return HttpResponse.json({ message: 'Not found' }, { status: 404 })
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 120))
+
+    const publication = publicationStore.ensure(id)
+
+    return HttpResponse.json(publication, { status: 200 })
+  }
+)
+
+export const updateBookHandler = http.put(
+  BOOK_DETAIL_ROUTE,
+  async ({ params, request }) => {
+    const id = params.id
+    if (typeof id !== 'string' || !id) {
+      return HttpResponse.json({ message: 'Not found' }, { status: 404 })
+    }
+
+    const publication = publicationStore.get(id)
+
+    if (!publication) {
+      return HttpResponse.json({ message: 'Not found' }, { status: 404 })
+    }
+
+    if (!publication.isOwner) {
+      return HttpResponse.json(
+        { message: 'Solo el dueño puede editar esta publicación.' },
+        { status: 403 }
+      )
+    }
+
+    const body = (await request.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >
+    const errors: Record<string, string[]> = {}
+
+    const metadata =
+      typeof body.metadata === 'object' && body.metadata
+        ? (body.metadata as Record<string, unknown>)
+        : undefined
+
+    if (metadata) {
+      const title = metadata.title
+      if (typeof title === 'string' && title.trim().length === 0) {
+        errors.metadata = ['El título no puede estar vacío.']
+      }
+    }
+
+    if ('price' in body && body.price) {
+      const price = body.price as Record<string, unknown>
+      if (
+        'amount' in price &&
+        price.amount !== null &&
+        typeof price.amount !== 'number'
+      ) {
+        errors.price = ['El precio debe ser un número o null.']
+      }
+    }
+
+    if (Object.keys(errors).length > 0) {
+      return HttpResponse.json(
+        { message: 'La publicación contiene errores.', errors },
+        { status: 400 }
+      )
+    }
+
+    const updated = publicationStore.update(id, body as PublicationUpdate)
+
+    return HttpResponse.json(updated, { status: 200 })
+  }
+)

--- a/frontend/mocks/handlers/books/fakers/books.faker.ts
+++ b/frontend/mocks/handlers/books/fakers/books.faker.ts
@@ -2,6 +2,8 @@ import { faker } from '@faker-js/faker'
 
 import { ApiBook } from '@src/api/books/books.types'
 
+import { publicationStore } from './publications.faker'
+
 interface BookData {
   author: string
   isbn: string
@@ -55,11 +57,23 @@ export const generateBooks = (
   language: string = 'es'
 ): ApiBook[] => {
   faker.seed(seed ?? 201)
-  return faker.helpers
+  const books = faker.helpers
     .arrayElements(BOOKS, 3)
-    .map(({ titles, author, isbn }) => ({
-      title: titles[language as 'en' | 'es'] || titles.es,
-      author,
-      coverUrl: coverFromIsbn(isbn),
-    }))
+    .map(({ titles, author, isbn }) => {
+      const id = faker.string.uuid()
+      const coverUrl = coverFromIsbn(isbn)
+      publicationStore.seedFromPreview(id, {
+        title: titles[language as 'en' | 'es'] || titles.es,
+        author,
+        coverUrl,
+        isOwner: false,
+      })
+      return {
+        id,
+        title: titles[language as 'en' | 'es'] || titles.es,
+        author,
+        coverUrl,
+      }
+    })
+  return books
 }

--- a/frontend/mocks/handlers/books/fakers/publications.faker.ts
+++ b/frontend/mocks/handlers/books/fakers/publications.faker.ts
@@ -1,0 +1,122 @@
+import { faker } from '@faker-js/faker'
+
+import { applyPublicationUpdate } from '@src/api/books/publication.utils'
+import type {
+  Publication,
+  PublicationImage,
+  PublicationStatus,
+  PublicationUpdate,
+} from '@src/api/books/publication.types'
+
+const publications = new Map<string, Publication>()
+
+const defaultImages = (coverUrl: string): PublicationImage[] => [
+  {
+    id: faker.string.uuid(),
+    url: coverUrl,
+    alt: 'Cover',
+    primary: true,
+  },
+  {
+    id: faker.string.uuid(),
+    url: `${coverUrl}&variant=1`,
+    alt: 'Back cover',
+  },
+]
+
+const buildPublication = (
+  id: string,
+  overrides?: Partial<Publication>
+): Publication => {
+  const title = overrides?.metadata?.title ?? faker.lorem.words(3)
+  const author = overrides?.metadata?.author ?? faker.person.fullName()
+  const cover =
+    overrides?.images?.[0]?.url ??
+    `https://placehold.co/400x600?text=${encodeURIComponent(title)}`
+
+  return {
+    id,
+    metadata: {
+      title,
+      author,
+      publisher: overrides?.metadata?.publisher ?? faker.company.name(),
+      year:
+        overrides?.metadata?.year ??
+        String(faker.date.past({ years: 20 }).getFullYear()),
+      language: overrides?.metadata?.language ?? 'es',
+    },
+    condition: overrides?.condition ?? 'good',
+    status: overrides?.status ?? 'available',
+    availability: overrides?.availability ?? 'public',
+    notes: overrides?.notes ?? faker.lorem.sentences({ min: 1, max: 2 }),
+    delivery: overrides?.delivery ?? {
+      inPerson: true,
+      nearBookCorner: faker.datatype.boolean(),
+      shipping: faker.datatype.boolean(),
+      shippingPayer: 'split',
+    },
+    price: overrides?.price ?? {
+      amount: faker.number.int({ min: 5000, max: 25000 }),
+      currency: 'ARS',
+    },
+    images: overrides?.images ?? defaultImages(cover),
+    isOwner: overrides?.isOwner ?? false,
+    createdAt:
+      overrides?.createdAt ?? faker.date.past({ years: 1 }).toISOString(),
+    updatedAt:
+      overrides?.updatedAt ?? faker.date.recent({ days: 30 }).toISOString(),
+  }
+}
+
+export const publicationStore = {
+  ensure: (id: string, overrides?: Partial<Publication>) => {
+    if (!publications.has(id)) {
+      const publication = buildPublication(id, overrides)
+      publications.set(id, publication)
+    } else if (overrides) {
+      const current = publications.get(id)
+      if (current) {
+        publications.set(id, { ...current, ...overrides })
+      }
+    }
+    return publications.get(id) ?? buildPublication(id, overrides)
+  },
+  upsert: (publication: Publication) => {
+    publications.set(publication.id, publication)
+    return publication
+  },
+  update: (id: string, input: PublicationUpdate) => {
+    const current = publications.get(id)
+    if (!current) {
+      throw new Error(`Publication ${id} not found`)
+    }
+    const next = applyPublicationUpdate(current, input)
+    publications.set(id, next)
+    return next
+  },
+  get: (id: string) => publications.get(id),
+  seedFromPreview: (
+    id: string,
+    seed: {
+      title: string
+      author: string
+      coverUrl?: string
+      status?: PublicationStatus
+      isOwner?: boolean
+    }
+  ) => {
+    const cover =
+      seed.coverUrl ??
+      `https://placehold.co/400x600?text=${encodeURIComponent(seed.title)}`
+    return publicationStore.ensure(id, {
+      metadata: {
+        title: seed.title,
+        author: seed.author,
+      },
+      status: seed.status ?? 'available',
+      isOwner: seed.isOwner ?? false,
+      images: defaultImages(cover),
+    })
+  },
+  all: () => Array.from(publications.values()),
+}

--- a/frontend/mocks/handlers/index.ts
+++ b/frontend/mocks/handlers/index.ts
@@ -2,6 +2,10 @@ import { loginHandler } from './auth/login.handler'
 import { logoutHandler } from './auth/logout.handler'
 import { authStateHandler, meHandler } from './auth/me.handler'
 import { registerHandler } from './auth/register.handler'
+import {
+  bookDetailHandler,
+  updateBookHandler,
+} from './books/bookDetail.handler'
 import { booksHandler } from './books/books.handler'
 import { publishBookHandler } from './books/publish.handler'
 import { searchBooksHandler } from './books/search.handler'
@@ -27,6 +31,8 @@ export const handlers = [
   authStateHandler,
   meHandler,
   booksHandler,
+  bookDetailHandler,
+  updateBookHandler,
   searchBooksHandler,
   publishBookHandler,
   userBooksHandler,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Toaster } from '@components/ui/toaster/Toaster'
 import { AuthProvider } from '@contexts/auth/AuthContext'
+import { BookDetailModalProvider } from '@contexts/book'
 import { ThemeProvider } from '@contexts/theme/ThemeContext'
 import { useUserLanguage } from '@hooks/language/useUserLanguage'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -23,10 +24,12 @@ const App = () => {
       <AuthProvider>
         <ThemeProvider>
           <LanguageInitializer />
-          <div>
-            <AppRoutes />
-            <Toaster />
-          </div>
+          <BookDetailModalProvider>
+            <div>
+              <AppRoutes />
+              <Toaster />
+            </div>
+          </BookDetailModalProvider>
         </ThemeProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/frontend/src/api/books/books.service.ts
+++ b/frontend/src/api/books/books.service.ts
@@ -1,8 +1,135 @@
+import { isAxiosError } from 'axios'
+
 import { apiClient } from '@src/api/axios'
 import { RELATIVE_API_ROUTES } from '@src/api/routes'
 
 import { ApiBook } from './books.types'
+import {
+  Publication,
+  PublicationApiError,
+  PublicationUpdate,
+  PublicationErrorType,
+} from './publication.types'
 import { PublishBookPayload, PublishBookResponse } from './publishBook.types'
+
+type ApiErrorResponse = {
+  message?: string
+  errors?: Record<string, string[]>
+}
+
+const parseApiError = (input: unknown): ApiErrorResponse => {
+  if (!input || typeof input !== 'object') {
+    return {}
+  }
+
+  const message =
+    'message' in input && typeof input.message === 'string'
+      ? input.message
+      : undefined
+
+  const errorsSource =
+    'errors' in input && typeof input.errors === 'object' && input.errors
+      ? (input.errors as Record<string, unknown>)
+      : undefined
+
+  if (!errorsSource) {
+    return { message }
+  }
+
+  const errors: Record<string, string[]> = {}
+
+  for (const [key, value] of Object.entries(errorsSource)) {
+    if (!Array.isArray(value)) continue
+    const entries = value.filter(
+      (item): item is string => typeof item === 'string'
+    )
+    if (entries.length > 0) {
+      errors[key] = entries
+    }
+  }
+
+  return {
+    message,
+    errors: Object.keys(errors).length > 0 ? errors : undefined,
+  }
+}
+
+const createPublicationError = (
+  type: PublicationErrorType,
+  fallbackMessage: string,
+  status?: number,
+  details?: Record<string, string[]>,
+  messageOverride?: string
+) =>
+  new PublicationApiError(
+    messageOverride || fallbackMessage,
+    type,
+    status,
+    details
+  )
+
+const mapPublicationError = (error: unknown): PublicationApiError => {
+  if (isAxiosError(error)) {
+    const { response, message } = error
+
+    if (!response) {
+      return createPublicationError(
+        'network',
+        'Network error',
+        undefined,
+        undefined,
+        message
+      )
+    }
+
+    const { status, data } = response
+    const parsed = parseApiError(data)
+
+    if (status === 404) {
+      return createPublicationError(
+        'not_found',
+        'Publication not found',
+        status,
+        parsed.errors,
+        parsed.message
+      )
+    }
+
+    if (status === 403) {
+      return createPublicationError(
+        'forbidden',
+        'You cannot edit this publication',
+        status,
+        parsed.errors,
+        parsed.message
+      )
+    }
+
+    if (status === 400) {
+      return createPublicationError(
+        'validation',
+        'The publication could not be updated',
+        status,
+        parsed.errors,
+        parsed.message
+      )
+    }
+
+    return createPublicationError(
+      'unknown',
+      'Unexpected publication error',
+      status,
+      parsed.errors,
+      parsed.message
+    )
+  }
+
+  if (error instanceof Error) {
+    return createPublicationError('unknown', error.message)
+  }
+
+  return createPublicationError('unknown', 'Unexpected publication error')
+}
 
 export const fetchBooks = async (): Promise<ApiBook[]> => {
   const response = await apiClient.get<ApiBook[]>(
@@ -29,4 +156,40 @@ export const publishBook = async (
   }
 
   return response.data
+}
+
+export const getBookById = async (id: string): Promise<Publication> => {
+  try {
+    const response = await apiClient.get<Publication>(
+      RELATIVE_API_ROUTES.BOOKS.DETAIL(id)
+    )
+
+    if (!response.data || typeof response.data !== 'object') {
+      throw new Error('Invalid publication response')
+    }
+
+    return response.data
+  } catch (error) {
+    throw mapPublicationError(error)
+  }
+}
+
+export const updateBook = async (
+  id: string,
+  input: PublicationUpdate
+): Promise<Publication> => {
+  try {
+    const response = await apiClient.put<Publication>(
+      RELATIVE_API_ROUTES.BOOKS.DETAIL(id),
+      input
+    )
+
+    if (!response.data || typeof response.data !== 'object') {
+      throw new Error('Invalid publication response')
+    }
+
+    return response.data
+  } catch (error) {
+    throw mapPublicationError(error)
+  }
 }

--- a/frontend/src/api/books/books.types.ts
+++ b/frontend/src/api/books/books.types.ts
@@ -3,6 +3,7 @@
  * TODO: extender con más metadatos del libro.
  */
 export type ApiBook = {
+  id?: string
   title: string
   author: string
   coverUrl: string

--- a/frontend/src/api/books/config.ts
+++ b/frontend/src/api/books/config.ts
@@ -1,0 +1,22 @@
+const RAW_MODE = (import.meta.env.PUBLIC_BOOKS_API_MODE || '').toLowerCase()
+
+export type BooksApiMode = 'mock' | 'live'
+
+const isValidMode = (value: string): value is BooksApiMode =>
+  value === 'mock' || value === 'live'
+
+export const BOOKS_API_MODE: BooksApiMode = isValidMode(RAW_MODE)
+  ? RAW_MODE
+  : 'mock'
+
+export const resolveBooksPath = (path: string): string => {
+  if (!path.startsWith('/')) {
+    return resolveBooksPath(`/${path}`)
+  }
+
+  if (BOOKS_API_MODE === 'mock') {
+    return `/api${path}`
+  }
+
+  return path
+}

--- a/frontend/src/api/books/publication.types.ts
+++ b/frontend/src/api/books/publication.types.ts
@@ -1,0 +1,88 @@
+export type PublicationStatus = 'available' | 'reserved' | 'completed' | 'draft'
+
+export type PublicationCondition =
+  | 'new'
+  | 'very_good'
+  | 'good'
+  | 'acceptable'
+  | 'unknown'
+
+export type PublicationAvailability = 'public' | 'private'
+
+export type PublicationDelivery = {
+  nearBookCorner: boolean
+  inPerson: boolean
+  shipping: boolean
+  shippingPayer: 'owner' | 'requester' | 'split'
+}
+
+export type PublicationPrice = {
+  amount: number | null
+  currency: string
+}
+
+export type PublicationImage = {
+  id: string
+  url: string
+  alt: string
+  primary?: boolean
+}
+
+export type PublicationMetadata = {
+  title: string
+  author: string
+  publisher?: string | null
+  year?: string | null
+  language?: string | null
+}
+
+export type Publication = {
+  id: string
+  metadata: PublicationMetadata
+  condition: PublicationCondition
+  status: PublicationStatus
+  availability: PublicationAvailability
+  notes: string
+  delivery: PublicationDelivery
+  price: PublicationPrice
+  images: PublicationImage[]
+  isOwner: boolean
+  updatedAt: string
+  createdAt: string
+}
+
+export type PublicationUpdate = {
+  metadata?: Partial<
+    Pick<PublicationMetadata, 'title' | 'author' | 'publisher' | 'year'>
+  >
+  notes?: string
+  condition?: PublicationCondition
+  status?: PublicationStatus
+  availability?: PublicationAvailability
+  delivery?: Partial<PublicationDelivery>
+  price?: Partial<PublicationPrice>
+  images?: PublicationImage[]
+}
+
+export type PublicationErrorType =
+  | 'not_found'
+  | 'forbidden'
+  | 'validation'
+  | 'network'
+  | 'unknown'
+
+export class PublicationApiError extends Error {
+  constructor(
+    message: string,
+    public readonly type: PublicationErrorType,
+    public readonly status?: number,
+    public readonly details?: Record<string, string[]>
+  ) {
+    super(message)
+    this.name = 'PublicationApiError'
+  }
+}
+
+export const isPublicationApiError = (
+  error: unknown
+): error is PublicationApiError => error instanceof PublicationApiError

--- a/frontend/src/api/books/publication.utils.ts
+++ b/frontend/src/api/books/publication.utils.ts
@@ -1,0 +1,30 @@
+import type { Publication, PublicationUpdate } from './publication.types'
+
+export const applyPublicationUpdate = (
+  publication: Publication,
+  input: PublicationUpdate
+): Publication => {
+  const price = input.price
+    ? { ...publication.price, ...input.price }
+    : publication.price
+
+  return {
+    ...publication,
+    metadata: input.metadata
+      ? { ...publication.metadata, ...input.metadata }
+      : publication.metadata,
+    notes: input.notes ?? publication.notes,
+    condition: input.condition ?? publication.condition,
+    status: input.status ?? publication.status,
+    availability: input.availability ?? publication.availability,
+    delivery: input.delivery
+      ? { ...publication.delivery, ...input.delivery }
+      : publication.delivery,
+    price: {
+      amount: price.amount ?? null,
+      currency: price.currency,
+    },
+    images: input.images ?? publication.images,
+    updatedAt: new Date().toISOString(),
+  }
+}

--- a/frontend/src/api/routes.ts
+++ b/frontend/src/api/routes.ts
@@ -1,3 +1,5 @@
+import { resolveBooksPath } from './books/config'
+
 export const RELATIVE_API_ROUTES = {
   AUTH: {
     LOGIN: `/auth/login`,
@@ -10,10 +12,11 @@ export const RELATIVE_API_ROUTES = {
     SUBMIT: `/contact/submit`,
   },
   BOOKS: {
-    LIST: `/books`,
-    MINE: `/books/mine`,
-    SEARCH: `/books/search`,
-    PUBLISH: `/books`,
+    LIST: resolveBooksPath('/books'),
+    MINE: resolveBooksPath('/books/mine'),
+    SEARCH: resolveBooksPath('/books/search'),
+    PUBLISH: resolveBooksPath('/books'),
+    DETAIL: (id: string) => resolveBooksPath(`/books/${id}`),
   },
   COMMUNITY: {
     STATS: `/community/stats`,

--- a/frontend/src/assets/i18n/locales/en/common.json
+++ b/frontend/src/assets/i18n/locales/en/common.json
@@ -112,14 +112,17 @@
       "available": "Available",
       "reserved": "Reserved",
       "sold": "Sold",
-      "exchanged": "Exchanged"
+      "exchanged": "Exchanged",
+      "completed": "Completed",
+      "draft": "Draft"
     },
     "badge": {
       "for_sale": "For sale · ${{price}}",
       "for_trade": "Trade",
       "seeking": "Seeking"
     },
-    "cover_alt": "Cover of {{title}}"
+    "cover_alt": "Cover of {{title}}",
+    "openDetail": "Open details for {{title}}"
   },
   "publishBook": {
     "title": "Publish a book",
@@ -633,6 +636,79 @@
       "timeLabel": "Time",
       "cancel": "Cancel",
       "confirm": "Confirm"
+    }
+  },
+  "bookDetail": {
+    "title": "Publication detail",
+    "subtitleOwner": "Keep your listing up to date",
+    "subtitleGuest": "Information shared with the community",
+    "roleDescription": "Modal dialog with publication details",
+    "status": {
+      "available": "Available",
+      "reserved": "Reserved",
+      "completed": "Completed",
+      "draft": "Draft"
+    },
+    "sections": {
+      "details": "Details",
+      "images": "Images"
+    },
+    "fields": {
+      "title": "Title",
+      "notes": "Notes",
+      "condition": "Condition",
+      "status": "Status",
+      "availability": "Availability",
+      "price": "Price",
+      "delivery": "Delivery options",
+      "publisher": "Publisher",
+      "year": "Year",
+      "updated": "Updated",
+      "imageUrl": "Image URL"
+    },
+    "availability": {
+      "public": "Visible to everyone",
+      "private": "Visible only to you"
+    },
+    "delivery": {
+      "inPerson": "In-person pickup",
+      "corner": "Book corner drop-off",
+      "shipping": "Shipping",
+      "shippingPayer": "Who pays for shipping",
+      "payer": {
+        "owner": "I cover it",
+        "requester": "Requester pays",
+        "split": "Split cost"
+      }
+    },
+    "actions": {
+      "save": "Save changes",
+      "saving": "Saving...",
+      "cancel": "Cancel",
+      "close": "Close",
+      "changeStatus": "Change status",
+      "addImage": "Add image",
+      "removeImage": "Remove"
+    },
+    "messages": {
+      "saved": "Publication updated",
+      "error": "We couldn't update the publication.",
+      "validation": "Please review the highlighted fields.",
+      "forbidden": "Only the owner can edit this publication.",
+      "notFound": "We couldn't find this publication.",
+      "network": "Connection failed. Try again.",
+      "noChanges": "No changes to save."
+    },
+    "validation": {
+      "price": "Enter a valid price or leave it empty."
+    },
+    "empty": "We couldn't find this publication.",
+    "emptyImages": "No images yet.",
+    "confirm": {
+      "close": "You have unsaved changes. Do you want to leave anyway?",
+      "reopen": "Are you sure you want to mark the book as available again?",
+      "cancel": "Cancel",
+      "accept": "Confirm"
     }
   }
 }

--- a/frontend/src/assets/i18n/locales/es/common.json
+++ b/frontend/src/assets/i18n/locales/es/common.json
@@ -112,14 +112,17 @@
       "available": "Disponible",
       "reserved": "Reservado",
       "sold": "Vendido",
-      "exchanged": "Intercambiado"
+      "exchanged": "Intercambiado",
+      "completed": "Completado",
+      "draft": "Borrador"
     },
     "badge": {
       "for_sale": "A la venta · ${{price}}",
       "for_trade": "Intercambio",
       "seeking": "Buscando"
     },
-    "cover_alt": "Portada de {{title}}"
+    "cover_alt": "Portada de {{title}}",
+    "openDetail": "Ver detalles de {{title}}"
   },
   "publishBook": {
     "title": "Publicar un libro",
@@ -272,6 +275,79 @@
       "price": "El precio debe ser mayor a 0"
     },
     "previewAlt": "Vista previa de la portada"
+  },
+  "bookDetail": {
+    "title": "Detalle de la publicación",
+    "subtitleOwner": "Actualizá la información para mantenerla al día",
+    "subtitleGuest": "Información visible para la comunidad",
+    "roleDescription": "Modal con información de la publicación",
+    "status": {
+      "available": "Disponible",
+      "reserved": "Reservado",
+      "completed": "Completado",
+      "draft": "Borrador"
+    },
+    "sections": {
+      "details": "Detalles",
+      "images": "Imágenes"
+    },
+    "fields": {
+      "title": "Título",
+      "notes": "Notas",
+      "condition": "Condición",
+      "status": "Estado",
+      "availability": "Disponibilidad",
+      "price": "Precio",
+      "delivery": "Opciones de entrega",
+      "publisher": "Editorial",
+      "year": "Año",
+      "updated": "Actualizado",
+      "imageUrl": "URL de la imagen"
+    },
+    "availability": {
+      "public": "Visible para todos",
+      "private": "Solo visible para vos"
+    },
+    "delivery": {
+      "inPerson": "Retiro en persona",
+      "corner": "Entrega en casita",
+      "shipping": "Envío",
+      "shippingPayer": "Quién paga el envío",
+      "payer": {
+        "owner": "Lo pago yo",
+        "requester": "Lo paga quien solicita",
+        "split": "Costo compartido"
+      }
+    },
+    "actions": {
+      "save": "Guardar cambios",
+      "saving": "Guardando...",
+      "cancel": "Cancelar",
+      "close": "Cerrar",
+      "changeStatus": "Cambiar estado",
+      "addImage": "Agregar imagen",
+      "removeImage": "Eliminar"
+    },
+    "messages": {
+      "saved": "Publicación actualizada",
+      "error": "No pudimos actualizar la publicación.",
+      "validation": "Revisá los campos marcados para continuar.",
+      "forbidden": "Solo el dueño puede editar esta publicación.",
+      "notFound": "No encontramos la publicación.",
+      "network": "No pudimos conectar. Probá de nuevo.",
+      "noChanges": "No hay cambios para guardar."
+    },
+    "validation": {
+      "price": "Ingresá un precio válido o dejalo vacío."
+    },
+    "empty": "No encontramos esta publicación.",
+    "emptyImages": "Sin imágenes cargadas.",
+    "confirm": {
+      "close": "Tenés cambios sin guardar. ¿Querés salir igualmente?",
+      "reopen": "¿Confirmás volver a marcar el libro como disponible?",
+      "cancel": "Cancelar",
+      "accept": "Confirmar"
+    }
   },
   "publishCorner": {
     "title": "Crear Rincón de Libros",

--- a/frontend/src/components/book/BookCard.module.scss
+++ b/frontend/src/components/book/BookCard.module.scss
@@ -1,6 +1,9 @@
 @import '@styles/variables';
 
 .card {
+  border: none;
+  text-align: left;
+  padding: 0;
   display: flex;
   flex-direction: column;
   width: rem(140px);
@@ -9,6 +12,11 @@
   border-radius: rem(8px);
   overflow: hidden;
   background-color: var(--background-card);
+
+  &:focus-visible {
+    outline: rem(3px) solid var(--primary-color);
+    outline-offset: rem(3px);
+  }
 
   &:hover {
     transform: scale(1.05);
@@ -62,6 +70,16 @@
   &.sold,
   &.exchanged {
     background-color: var(--color-neutral-500);
+    color: #fff;
+  }
+
+  &.completed {
+    background-color: var(--color-neutral-500);
+    color: #fff;
+  }
+
+  &.draft {
+    background-color: var(--color-info);
     color: #fff;
   }
 }

--- a/frontend/src/components/book/BookCard.tsx
+++ b/frontend/src/components/book/BookCard.tsx
@@ -1,10 +1,12 @@
 import { BookCardProps } from '@components/book/BookCard.types'
-import React from 'react'
+import { BookDetailModalContext } from '@contexts/book/BookDetailModalContext'
+import React, { useCallback, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import styles from './BookCard.module.scss'
 
 export const BookCard: React.FC<BookCardProps> = ({
+  id,
   title,
   author,
   coverUrl,
@@ -17,6 +19,7 @@ export const BookCard: React.FC<BookCardProps> = ({
   isSeeking,
 }) => {
   const { t } = useTranslation()
+  const modal = useContext(BookDetailModalContext)
 
   const conditionLabel = (() => {
     if (!condition) return null
@@ -28,6 +31,12 @@ export const BookCard: React.FC<BookCardProps> = ({
     return condition
   })()
 
+  const handleOpen = useCallback(() => {
+    if (id && modal?.open) {
+      modal.open(id)
+    }
+  }, [id, modal])
+
   const renderTradePreferences = () => {
     if (!tradePreferences || tradePreferences.length === 0) return null
     const shown = tradePreferences.slice(0, 3).join(', ')
@@ -37,7 +46,12 @@ export const BookCard: React.FC<BookCardProps> = ({
   }
 
   return (
-    <div className={styles.card}>
+    <button
+      type="button"
+      className={styles.card}
+      onClick={handleOpen}
+      aria-label={t('booksPage.openDetail', { title })}
+    >
       <img
         src={coverUrl}
         alt={t('booksPage.cover_alt', { title })}
@@ -78,6 +92,6 @@ export const BookCard: React.FC<BookCardProps> = ({
           )}
         </div>
       </div>
-    </div>
+    </button>
   )
 }

--- a/frontend/src/components/book/BookCard.types.ts
+++ b/frontend/src/components/book/BookCard.types.ts
@@ -3,11 +3,18 @@
  * TODO: unificar los estados en un enum reutilizable.
  */
 export type BookCardProps = {
+  id?: string
   title: string
   author: string
   coverUrl: string
   condition?: string
-  status?: 'available' | 'reserved' | 'sold' | 'exchanged'
+  status?:
+    | 'available'
+    | 'reserved'
+    | 'sold'
+    | 'exchanged'
+    | 'completed'
+    | 'draft'
   isForSale?: boolean
   price?: number | null
   isForTrade?: boolean

--- a/frontend/src/components/book/EditBookModal/EditBookModal.module.scss
+++ b/frontend/src/components/book/EditBookModal/EditBookModal.module.scss
@@ -1,0 +1,317 @@
+@import '@styles/variables';
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: rem(24px);
+}
+
+.heroRow {
+  display: grid;
+  grid-template-columns: minmax(200px, 240px) 1fr;
+  gap: rem(24px);
+}
+
+.heroImage {
+  width: 100%;
+  border-radius: rem(12px);
+  object-fit: cover;
+  box-shadow: 0 16px 32px rgb(8 15 32 / 18%);
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: rem(12px);
+}
+
+.metaHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: rem(12px);
+}
+
+.metaAuthor {
+  font-size: 1rem;
+  color: var(--text-secondary);
+}
+
+.metaList {
+  display: grid;
+  gap: rem(8px);
+  font-size: 0.9rem;
+}
+
+.metaList dt {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.metaList dd {
+  margin: 0;
+}
+
+.statusBadge {
+  border-radius: 999px;
+  padding: rem(6px) rem(14px);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: rgb(var(--primary-super-dark-rgb) / 10%);
+  color: var(--primary-dark);
+}
+
+.statusBadge.available {
+  background: rgb(var(--success-rgb) / 12%);
+  color: var(--success-color);
+}
+
+.statusBadge.reserved {
+  background: rgb(var(--warning-rgb) / 12%);
+  color: var(--warning-color);
+}
+
+.statusBadge.completed {
+  background: rgb(var(--neutral-700-rgb) / 12%);
+  color: var(--neutral-700);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: rem(16px);
+}
+
+.section h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.formGrid {
+  display: grid;
+  gap: rem(16px);
+}
+
+.fieldLabel {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+select,
+input,
+textarea {
+  padding: rem(10px) rem(12px);
+  border-radius: rem(8px);
+  border: 1px solid rgb(8 15 32 / 15%);
+  font: inherit;
+  background: var(--background-secondary);
+}
+
+input:disabled,
+select:disabled,
+textarea:disabled {
+  cursor: not-allowed;
+  background: rgb(8 15 32 / 6%);
+}
+
+.availabilityGroup {
+  display: grid;
+  gap: rem(8px);
+  border: 1px solid rgb(8 15 32 / 12%);
+  border-radius: rem(12px);
+  padding: rem(12px);
+}
+
+.availabilityGroup legend {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.priceRow {
+  display: grid;
+  gap: rem(8px);
+}
+
+.priceInputs {
+  display: flex;
+  gap: rem(12px);
+  align-items: center;
+}
+
+.currencyInput {
+  width: 96px;
+  text-transform: uppercase;
+}
+
+.inlineError {
+  color: var(--error-500, #c62828);
+  font-size: 0.85rem;
+}
+
+.deliveryGroup {
+  display: grid;
+  gap: rem(10px);
+  border: 1px solid rgb(8 15 32 / 12%);
+  border-radius: rem(12px);
+  padding: rem(12px);
+}
+
+.shippingPayer {
+  display: flex;
+  flex-direction: column;
+  gap: rem(6px);
+  font-size: 0.9rem;
+}
+
+.imagesSection {
+  display: flex;
+  flex-direction: column;
+  gap: rem(16px);
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: rem(12px);
+}
+
+.addImageButton,
+.removeImageButton,
+.errorState button {
+  border: none;
+  background: var(--primary-color);
+  color: #fff;
+  border-radius: rem(8px);
+  padding: rem(8px) rem(14px);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.removeImageButton {
+  background: rgb(var(--error-rgb) / 85%);
+}
+
+.addImageButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.imageList {
+  display: grid;
+  gap: rem(16px);
+}
+
+.imageItem {
+  display: grid;
+  gap: rem(8px);
+  border: 1px solid rgb(8 15 32 / 12%);
+  border-radius: rem(12px);
+  padding: rem(12px);
+}
+
+.imageItem img {
+  width: 100%;
+  max-height: 220px;
+  object-fit: cover;
+  border-radius: rem(10px);
+}
+
+.empty {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.loading {
+  display: grid;
+  gap: rem(12px);
+}
+
+.skeleton {
+  height: rem(120px);
+  border-radius: rem(12px);
+  background: linear-gradient(
+    90deg,
+    rgb(8 15 32 / 8%),
+    rgb(8 15 32 / 16%),
+    rgb(8 15 32 / 8%)
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.errorState {
+  display: flex;
+  flex-direction: column;
+  gap: rem(16px);
+  align-items: flex-start;
+}
+
+.confirmOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgb(8 15 32 / 45%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.confirmDialog {
+  background: var(--background-primary);
+  padding: rem(24px);
+  border-radius: rem(12px);
+  display: grid;
+  gap: rem(16px);
+  max-width: 360px;
+}
+
+.confirmActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: rem(12px);
+}
+
+.confirmActions button {
+  border: none;
+  padding: rem(8px) rem(14px);
+  border-radius: rem(8px);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.confirmActions button:first-child {
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.confirmActions button:last-child {
+  background: var(--primary-color);
+  color: #fff;
+}
+
+@media (width <= 768px) {
+  .heroRow {
+    grid-template-columns: 1fr;
+  }
+
+  .metaHeader {
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/components/book/EditBookModal/EditBookModal.tsx
+++ b/frontend/src/components/book/EditBookModal/EditBookModal.tsx
@@ -1,0 +1,794 @@
+import { useBookDetails } from '@hooks/api/useBookDetails'
+import { useUpdateBook } from '@hooks/api/useUpdateBook'
+import { useFocusTrap } from '@hooks/useFocusTrap'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  Publication,
+  PublicationApiError,
+  PublicationAvailability,
+  PublicationCondition,
+  PublicationImage,
+  PublicationStatus,
+  PublicationUpdate,
+  isPublicationApiError,
+} from '@src/api/books/publication.types'
+import { PublishModal } from '@src/components/publish/shared/PublishModal/PublishModal'
+import { PublishModalActions } from '@src/components/publish/shared/PublishModalActions/PublishModalActions'
+import { showToast } from '@src/components/ui/toaster/Toaster'
+import { track } from '@src/utils/analytics'
+import { cx } from '@src/utils/cx'
+
+import styles from './EditBookModal.module.scss'
+
+type EditBookModalProps = {
+  bookId: string | null
+  isOpen: boolean
+  onClose: () => void
+}
+
+type FormState = {
+  title: string
+  author: string
+  publisher: string
+  year: string
+  notes: string
+  condition: PublicationCondition
+  status: PublicationStatus
+  availability: PublicationAvailability
+  priceAmount: string
+  priceCurrency: string
+  delivery: {
+    nearBookCorner: boolean
+    inPerson: boolean
+    shipping: boolean
+    shippingPayer: 'owner' | 'requester' | 'split'
+  }
+  images: PublicationImage[]
+}
+
+const STATUS_FLOW: PublicationStatus[] = ['available', 'reserved', 'completed']
+const CONDITION_OPTIONS: PublicationCondition[] = [
+  'new',
+  'very_good',
+  'good',
+  'acceptable',
+  'unknown',
+]
+
+const createImageId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return `img-${Math.random().toString(36).slice(2, 9)}`
+}
+
+const publicationToFormState = (publication: Publication): FormState => ({
+  title: publication.metadata.title,
+  author: publication.metadata.author,
+  publisher: publication.metadata.publisher ?? '',
+  year: publication.metadata.year ?? '',
+  notes: publication.notes,
+  condition: publication.condition,
+  status: publication.status,
+  availability: publication.availability,
+  priceAmount:
+    publication.price.amount === null
+      ? ''
+      : String(publication.price.amount ?? ''),
+  priceCurrency: publication.price.currency,
+  delivery: {
+    nearBookCorner: publication.delivery.nearBookCorner,
+    inPerson: publication.delivery.inPerson,
+    shipping: publication.delivery.shipping,
+    shippingPayer: publication.delivery.shippingPayer,
+  },
+  images: publication.images,
+})
+
+const normalizeAmount = (amount: string): number | null => {
+  const trimmed = amount.trim()
+  if (!trimmed) return null
+  const parsed = Number(trimmed.replace(/,/g, '.'))
+  return Number.isFinite(parsed) ? parsed : NaN
+}
+
+const buildUpdatePayload = (
+  original: Publication,
+  form: FormState
+): PublicationUpdate => {
+  const update: PublicationUpdate = {}
+  const metadataDiff: PublicationUpdate['metadata'] = {}
+
+  if (form.title !== original.metadata.title) {
+    metadataDiff.title = form.title
+  }
+
+  if (form.author !== original.metadata.author) {
+    metadataDiff.author = form.author
+  }
+
+  if ((original.metadata.publisher ?? '') !== form.publisher) {
+    metadataDiff.publisher = form.publisher
+  }
+
+  if ((original.metadata.year ?? '') !== form.year) {
+    metadataDiff.year = form.year
+  }
+
+  if (Object.keys(metadataDiff).length > 0) {
+    update.metadata = metadataDiff
+  }
+
+  if (form.notes !== original.notes) {
+    update.notes = form.notes
+  }
+
+  if (form.condition !== original.condition) {
+    update.condition = form.condition
+  }
+
+  if (form.status !== original.status) {
+    update.status = form.status
+  }
+
+  if (form.availability !== original.availability) {
+    update.availability = form.availability
+  }
+
+  const amount = normalizeAmount(form.priceAmount)
+  if (
+    amount !== original.price.amount ||
+    form.priceCurrency !== original.price.currency
+  ) {
+    update.price = {
+      amount: Number.isNaN(amount) ? original.price.amount : amount,
+      currency: form.priceCurrency,
+    }
+  }
+
+  const deliveryChanged =
+    form.delivery.nearBookCorner !== original.delivery.nearBookCorner ||
+    form.delivery.inPerson !== original.delivery.inPerson ||
+    form.delivery.shipping !== original.delivery.shipping ||
+    form.delivery.shippingPayer !== original.delivery.shippingPayer
+
+  if (deliveryChanged) {
+    update.delivery = { ...form.delivery }
+  }
+
+  const originalImages = original.images
+  const imagesChanged =
+    form.images.length !== originalImages.length ||
+    form.images.some((image, index) => image.url !== originalImages[index]?.url)
+
+  if (imagesChanged) {
+    update.images = form.images.map((image, index) => ({
+      ...image,
+      id: image.id || originalImages[index]?.id || createImageId(),
+      alt: image.alt || originalImages[index]?.alt || original.metadata.title,
+    }))
+  }
+
+  return update
+}
+
+const hasUpdates = (update: PublicationUpdate) =>
+  Object.values(update).some((value) => value !== undefined)
+
+const mapErrorToMessageKey = (error: PublicationApiError): string => {
+  switch (error.type) {
+    case 'not_found':
+      return 'bookDetail.messages.notFound'
+    case 'forbidden':
+      return 'bookDetail.messages.forbidden'
+    case 'validation':
+      return 'bookDetail.messages.validation'
+    case 'network':
+      return 'bookDetail.messages.network'
+    default:
+      return 'bookDetail.messages.error'
+  }
+}
+
+export const EditBookModal = ({
+  bookId,
+  isOpen,
+  onClose,
+}: EditBookModalProps) => {
+  const { t } = useTranslation()
+  const modalRef = useRef<HTMLDivElement | null>(null)
+  const [formState, setFormState] = useState<FormState | null>(null)
+  const [original, setOriginal] = useState<Publication | null>(null)
+  const [showStatusConfirm, setShowStatusConfirm] =
+    useState<PublicationStatus | null>(null)
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  const { data, status, error } = useBookDetails(isOpen ? bookId : null)
+  const updateMutation = useUpdateBook(isOpen ? bookId : null)
+
+  useFocusTrap({
+    containerRef: modalRef,
+    active: isOpen,
+    onEscape: () => handleClose(),
+  })
+
+  useEffect(() => {
+    if (!isOpen) {
+      setFormState(null)
+      setOriginal(null)
+      setLocalError(null)
+      return
+    }
+
+    if (data) {
+      setOriginal(data)
+      setFormState(publicationToFormState(data))
+      setLocalError(null)
+      track('view_book_detail', {
+        bookId: data.id,
+        status: data.status,
+        isOwner: data.isOwner,
+      })
+      if (data.isOwner) {
+        track('open_edit_book', { bookId: data.id })
+      }
+    }
+  }, [data, isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const beforeUnload = (event: BeforeUnloadEvent) => {
+      if (!formState || !original) return
+      const update = buildUpdatePayload(original, formState)
+      if (!hasUpdates(update)) return
+      event.preventDefault()
+      event.returnValue = ''
+    }
+
+    window.addEventListener('beforeunload', beforeUnload)
+    return () => {
+      window.removeEventListener('beforeunload', beforeUnload)
+    }
+  }, [formState, isOpen, original])
+
+  const updatePayload = useMemo(() => {
+    if (!formState || !original) return undefined
+    return buildUpdatePayload(original, formState)
+  }, [formState, original])
+
+  const isDirty = Boolean(updatePayload && hasUpdates(updatePayload))
+  const isOwner = data?.isOwner ?? false
+
+  const handleClose = () => {
+    if (isDirty && isOwner) {
+      const shouldClose = window.confirm(t('bookDetail.confirm.close'))
+      if (!shouldClose) return
+    }
+    onClose()
+  }
+
+  const handleSave = async () => {
+    if (!isOwner || !formState || !original || !updatePayload) return
+    if (!hasUpdates(updatePayload)) {
+      showToast(t('bookDetail.messages.noChanges'), 'info')
+      return
+    }
+
+    const amount = normalizeAmount(formState.priceAmount)
+    if (Number.isNaN(amount)) {
+      setLocalError(t('bookDetail.validation.price'))
+      return
+    }
+
+    setLocalError(null)
+
+    try {
+      const result = await updateMutation.mutateAsync(updatePayload)
+      setOriginal(result)
+      setFormState(publicationToFormState(result))
+      showToast(t('bookDetail.messages.saved'), 'success')
+      track('save_edit_book_success', { bookId: result.id })
+    } catch (mutationError) {
+      const messageKey = isPublicationApiError(mutationError)
+        ? mapErrorToMessageKey(mutationError)
+        : 'bookDetail.messages.error'
+      showToast(t(messageKey), 'error')
+      track('save_edit_book_error', {
+        bookId: original.id,
+        error: isPublicationApiError(mutationError)
+          ? mutationError.type
+          : 'unknown',
+      })
+    }
+  }
+
+  const handleFieldChange = (changes: Partial<FormState>) => {
+    setFormState((prev) => (prev ? { ...prev, ...changes } : prev))
+  }
+
+  const handleDeliveryChange = (
+    field: keyof FormState['delivery'],
+    value: FormState['delivery'][typeof field]
+  ) => {
+    setFormState((prev) =>
+      prev
+        ? {
+            ...prev,
+            delivery: {
+              ...prev.delivery,
+              [field]: value,
+            },
+          }
+        : prev
+    )
+  }
+
+  const handleImageUrlChange = (index: number, value: string) => {
+    setFormState((prev) => {
+      if (!prev) return prev
+      const images = [...prev.images]
+      images[index] = {
+        ...images[index],
+        url: value,
+      }
+      return { ...prev, images }
+    })
+  }
+
+  const handleRemoveImage = (index: number) => {
+    setFormState((prev) => {
+      if (!prev) return prev
+      const images = prev.images.filter((_, idx) => idx !== index)
+      return { ...prev, images }
+    })
+  }
+
+  const handleAddImage = () => {
+    setFormState((prev) => {
+      if (!prev) return prev
+      const image: PublicationImage = {
+        id: createImageId(),
+        url: '',
+        alt: prev.title,
+      }
+      return { ...prev, images: [...prev.images, image] }
+    })
+  }
+
+  const handleCycleStatus = () => {
+    if (!formState) return
+    const currentIndex = STATUS_FLOW.indexOf(formState.status)
+    const nextStatus = STATUS_FLOW[(currentIndex + 1) % STATUS_FLOW.length]
+    if (formState.status === 'completed' && nextStatus === 'available') {
+      setShowStatusConfirm(nextStatus)
+      return
+    }
+    handleFieldChange({ status: nextStatus })
+  }
+
+  const confirmStatusChange = (statusToApply: PublicationStatus) => {
+    setFormState((prev) => (prev ? { ...prev, status: statusToApply } : prev))
+    setShowStatusConfirm(null)
+  }
+
+  const cancelStatusChange = () => setShowStatusConfirm(null)
+
+  const renderStatusBadge = () => {
+    if (!formState) return null
+    return (
+      <span className={cx(styles.statusBadge, styles[formState.status])}>
+        {t(`bookDetail.status.${formState.status}`)}
+      </span>
+    )
+  }
+
+  const renderImages = () => {
+    if (!formState) return null
+    return (
+      <div className={styles.imagesSection}>
+        <header className={styles.sectionHeader}>
+          <h3>{t('bookDetail.sections.images')}</h3>
+          {isOwner ? (
+            <button
+              type="button"
+              onClick={handleAddImage}
+              className={styles.addImageButton}
+              disabled={!isOwner}
+            >
+              {t('bookDetail.actions.addImage')}
+            </button>
+          ) : null}
+        </header>
+        <div className={styles.imageList}>
+          {formState.images.length === 0 ? (
+            <p className={styles.empty}>{t('bookDetail.emptyImages')}</p>
+          ) : (
+            formState.images.map((image, index) => (
+              <div key={image.id} className={styles.imageItem}>
+                <img src={image.url} alt={image.alt} />
+                {isOwner ? (
+                  <>
+                    <label
+                      className={styles.fieldLabel}
+                      htmlFor={`image-${image.id}`}
+                    >
+                      {t('bookDetail.fields.imageUrl')}
+                    </label>
+                    <input
+                      id={`image-${image.id}`}
+                      type="url"
+                      value={image.url}
+                      onChange={(event) =>
+                        handleImageUrlChange(index, event.target.value)
+                      }
+                      disabled={!isOwner}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveImage(index)}
+                      className={styles.removeImageButton}
+                    >
+                      {t('bookDetail.actions.removeImage')}
+                    </button>
+                  </>
+                ) : null}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  const footer = (
+    <PublishModalActions
+      leftActions={[
+        {
+          label: t('bookDetail.actions.cancel'),
+          onClick: handleClose,
+          variant: 'ghost',
+        },
+      ]}
+      rightActions={
+        isOwner
+          ? [
+              {
+                label: t('bookDetail.actions.changeStatus'),
+                onClick: handleCycleStatus,
+                disabled: !formState,
+                variant: 'secondary',
+              },
+              {
+                label: updateMutation.isPending
+                  ? t('bookDetail.actions.saving')
+                  : t('bookDetail.actions.save'),
+                onClick: handleSave,
+                disabled: !isDirty || updateMutation.isPending || !formState,
+                variant: 'primary',
+              },
+            ]
+          : [
+              {
+                label: t('bookDetail.actions.close'),
+                onClick: handleClose,
+                variant: 'secondary',
+              },
+            ]
+      }
+    />
+  )
+
+  const renderContent = () => {
+    if (status === 'pending' || (isOpen && !formState && !error)) {
+      return (
+        <div className={styles.loading}>
+          <div className={styles.skeleton} />
+          <div className={styles.skeleton} />
+          <div className={styles.skeleton} />
+        </div>
+      )
+    }
+
+    if (error) {
+      const messageKey = isPublicationApiError(error)
+        ? mapErrorToMessageKey(error)
+        : 'bookDetail.messages.error'
+      return (
+        <div className={styles.errorState}>
+          <p>{t(messageKey)}</p>
+          <button type="button" onClick={handleClose}>
+            {t('bookDetail.actions.close')}
+          </button>
+        </div>
+      )
+    }
+
+    if (!formState || !original) {
+      return (
+        <div className={styles.errorState}>
+          <p>{t('bookDetail.empty')}</p>
+          <button type="button" onClick={handleClose}>
+            {t('bookDetail.actions.close')}
+          </button>
+        </div>
+      )
+    }
+
+    return (
+      <div className={styles.content}>
+        <div className={styles.heroRow}>
+          <img
+            src={formState.images[0]?.url ?? ''}
+            alt={formState.images[0]?.alt ?? formState.title}
+            className={styles.heroImage}
+          />
+          <div className={styles.meta}>
+            <div className={styles.metaHeader}>
+              <h2>{formState.title}</h2>
+              {renderStatusBadge()}
+            </div>
+            <p className={styles.metaAuthor}>{formState.author}</p>
+            <dl className={styles.metaList}>
+              {formState.publisher ? (
+                <div>
+                  <dt>{t('bookDetail.fields.publisher')}</dt>
+                  <dd>{formState.publisher}</dd>
+                </div>
+              ) : null}
+              {formState.year ? (
+                <div>
+                  <dt>{t('bookDetail.fields.year')}</dt>
+                  <dd>{formState.year}</dd>
+                </div>
+              ) : null}
+              <div>
+                <dt>{t('bookDetail.fields.updated')}</dt>
+                <dd>{new Date(original.updatedAt).toLocaleString()}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+
+        <section className={styles.section}>
+          <h3>{t('bookDetail.sections.details')}</h3>
+          <div className={styles.formGrid}>
+            <label className={styles.fieldLabel} htmlFor="book-title">
+              {t('bookDetail.fields.title')}
+            </label>
+            <input
+              id="book-title"
+              type="text"
+              value={formState.title}
+              onChange={(event) =>
+                handleFieldChange({ title: event.target.value })
+              }
+              disabled={!isOwner}
+            />
+
+            <label className={styles.fieldLabel} htmlFor="book-notes">
+              {t('bookDetail.fields.notes')}
+            </label>
+            <textarea
+              id="book-notes"
+              value={formState.notes}
+              onChange={(event) =>
+                handleFieldChange({ notes: event.target.value })
+              }
+              disabled={!isOwner}
+            />
+
+            <label className={styles.fieldLabel} htmlFor="book-condition">
+              {t('bookDetail.fields.condition')}
+            </label>
+            <select
+              id="book-condition"
+              value={formState.condition}
+              onChange={(event) =>
+                handleFieldChange({
+                  condition: event.target.value as PublicationCondition,
+                })
+              }
+              disabled={!isOwner}
+            >
+              {CONDITION_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {t(`publishBook.offer.condition.options.${option}`)}
+                </option>
+              ))}
+            </select>
+
+            <label className={styles.fieldLabel} htmlFor="book-status">
+              {t('bookDetail.fields.status')}
+            </label>
+            <select
+              id="book-status"
+              value={formState.status}
+              onChange={(event) => {
+                const nextStatus = event.target.value as PublicationStatus
+                if (
+                  formState.status === 'completed' &&
+                  nextStatus === 'available'
+                ) {
+                  setShowStatusConfirm(nextStatus)
+                  return
+                }
+                handleFieldChange({ status: nextStatus })
+              }}
+              disabled={!isOwner}
+            >
+              {STATUS_FLOW.map((statusOption) => (
+                <option key={statusOption} value={statusOption}>
+                  {t(`bookDetail.status.${statusOption}`)}
+                </option>
+              ))}
+            </select>
+
+            <fieldset className={styles.availabilityGroup}>
+              <legend>{t('bookDetail.fields.availability')}</legend>
+              <label>
+                <input
+                  type="radio"
+                  name="availability"
+                  value="public"
+                  checked={formState.availability === 'public'}
+                  onChange={() => handleFieldChange({ availability: 'public' })}
+                  disabled={!isOwner}
+                />
+                {t('bookDetail.availability.public')}
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="availability"
+                  value="private"
+                  checked={formState.availability === 'private'}
+                  onChange={() =>
+                    handleFieldChange({ availability: 'private' })
+                  }
+                  disabled={!isOwner}
+                />
+                {t('bookDetail.availability.private')}
+              </label>
+            </fieldset>
+
+            <div className={styles.priceRow}>
+              <label className={styles.fieldLabel} htmlFor="book-price">
+                {t('bookDetail.fields.price')}
+              </label>
+              <div className={styles.priceInputs}>
+                <input
+                  id="book-price"
+                  type="number"
+                  inputMode="decimal"
+                  value={formState.priceAmount}
+                  onChange={(event) =>
+                    handleFieldChange({ priceAmount: event.target.value })
+                  }
+                  disabled={!isOwner}
+                />
+                <input
+                  id="book-currency"
+                  type="text"
+                  value={formState.priceCurrency}
+                  onChange={(event) =>
+                    handleFieldChange({ priceCurrency: event.target.value })
+                  }
+                  disabled={!isOwner}
+                  className={styles.currencyInput}
+                />
+              </div>
+              {localError ? (
+                <p className={styles.inlineError}>{localError}</p>
+              ) : null}
+            </div>
+
+            <fieldset className={styles.deliveryGroup}>
+              <legend>{t('bookDetail.fields.delivery')}</legend>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={formState.delivery.inPerson}
+                  onChange={(event) =>
+                    handleDeliveryChange('inPerson', event.target.checked)
+                  }
+                  disabled={!isOwner}
+                />
+                {t('bookDetail.delivery.inPerson')}
+              </label>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={formState.delivery.nearBookCorner}
+                  onChange={(event) =>
+                    handleDeliveryChange('nearBookCorner', event.target.checked)
+                  }
+                  disabled={!isOwner}
+                />
+                {t('bookDetail.delivery.corner')}
+              </label>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={formState.delivery.shipping}
+                  onChange={(event) =>
+                    handleDeliveryChange('shipping', event.target.checked)
+                  }
+                  disabled={!isOwner}
+                />
+                {t('bookDetail.delivery.shipping')}
+              </label>
+              <label className={styles.shippingPayer}>
+                <span>{t('bookDetail.delivery.shippingPayer')}</span>
+                <select
+                  value={formState.delivery.shippingPayer}
+                  onChange={(event) =>
+                    handleDeliveryChange(
+                      'shippingPayer',
+                      event.target
+                        .value as FormState['delivery']['shippingPayer']
+                    )
+                  }
+                  disabled={!isOwner || !formState.delivery.shipping}
+                >
+                  <option value="owner">
+                    {t('bookDetail.delivery.payer.owner')}
+                  </option>
+                  <option value="requester">
+                    {t('bookDetail.delivery.payer.requester')}
+                  </option>
+                  <option value="split">
+                    {t('bookDetail.delivery.payer.split')}
+                  </option>
+                </select>
+              </label>
+            </fieldset>
+          </div>
+        </section>
+
+        {renderImages()}
+      </div>
+    )
+  }
+
+  return (
+    <PublishModal
+      ref={modalRef}
+      isOpen={isOpen}
+      title={t('bookDetail.title')}
+      subtitle={t(
+        isOwner ? 'bookDetail.subtitleOwner' : 'bookDetail.subtitleGuest'
+      )}
+      onClose={handleClose}
+      closeLabel={t('bookDetail.actions.close')}
+      footer={footer}
+      roleDescription={t('bookDetail.roleDescription')}
+    >
+      {renderContent()}
+
+      {showStatusConfirm ? (
+        <div className={styles.confirmOverlay}>
+          <div
+            className={styles.confirmDialog}
+            role="alertdialog"
+            aria-modal="true"
+          >
+            <p>{t('bookDetail.confirm.reopen')}</p>
+            <div className={styles.confirmActions}>
+              <button type="button" onClick={cancelStatusChange}>
+                {t('bookDetail.confirm.cancel')}
+              </button>
+              <button
+                type="button"
+                onClick={() => confirmStatusChange(showStatusConfirm)}
+              >
+                {t('bookDetail.confirm.accept')}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </PublishModal>
+  )
+}

--- a/frontend/src/components/book/EditBookModal/index.ts
+++ b/frontend/src/components/book/EditBookModal/index.ts
@@ -1,0 +1,1 @@
+export { EditBookModal } from './EditBookModal'

--- a/frontend/src/contexts/book/BookDetailModalContext.tsx
+++ b/frontend/src/contexts/book/BookDetailModalContext.tsx
@@ -1,0 +1,60 @@
+import { EditBookModal } from '@components/book/EditBookModal'
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+
+type BookDetailModalContextValue = {
+  open: (bookId: string) => void
+  close: () => void
+  bookId: string | null
+}
+
+export const BookDetailModalContext =
+  createContext<BookDetailModalContextValue | null>(null)
+
+export const BookDetailModalProvider = ({
+  children,
+}: {
+  children: ReactNode
+}) => {
+  const [bookId, setBookId] = useState<string | null>(null)
+
+  const open = useCallback((id: string) => {
+    setBookId(id)
+  }, [])
+
+  const close = useCallback(() => {
+    setBookId(null)
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      open,
+      close,
+      bookId,
+    }),
+    [bookId, close, open]
+  )
+
+  return (
+    <BookDetailModalContext.Provider value={value}>
+      {children}
+      <EditBookModal bookId={bookId} isOpen={bookId !== null} onClose={close} />
+    </BookDetailModalContext.Provider>
+  )
+}
+
+export const useBookDetailModal = () => {
+  const context = useContext(BookDetailModalContext)
+  if (!context) {
+    throw new Error(
+      'useBookDetailModal must be used within BookDetailModalProvider'
+    )
+  }
+  return context
+}

--- a/frontend/src/contexts/book/index.ts
+++ b/frontend/src/contexts/book/index.ts
@@ -1,0 +1,4 @@
+export {
+  BookDetailModalProvider,
+  useBookDetailModal,
+} from './BookDetailModalContext'

--- a/frontend/src/hooks/api/useBookDetails.ts
+++ b/frontend/src/hooks/api/useBookDetails.ts
@@ -1,0 +1,25 @@
+import { getBookById } from '@api/books/books.service'
+import { Publication, PublicationApiError } from '@api/books/publication.types'
+import { useQuery } from '@tanstack/react-query'
+
+export const BOOK_DETAIL_QUERY_KEY = (id: string) => ['book', id] as const
+
+export const useBookDetails = (id: string | null) =>
+  useQuery<Publication, PublicationApiError>({
+    queryKey: BOOK_DETAIL_QUERY_KEY(id ?? ''),
+    queryFn: () => {
+      if (!id) {
+        throw new PublicationApiError('Missing publication id', 'unknown')
+      }
+      return getBookById(id)
+    },
+    enabled: Boolean(id),
+    retry: (failureCount, error) => {
+      if (!id) return false
+      if (error.type === 'not_found' || error.type === 'forbidden') {
+        return false
+      }
+      return failureCount < 2
+    },
+    staleTime: 1000 * 30,
+  })

--- a/frontend/src/hooks/api/useUpdateBook.ts
+++ b/frontend/src/hooks/api/useUpdateBook.ts
@@ -1,0 +1,56 @@
+import { updateBook } from '@api/books/books.service'
+import {
+  Publication,
+  PublicationApiError,
+  PublicationUpdate,
+} from '@api/books/publication.types'
+import { applyPublicationUpdate } from '@api/books/publication.utils'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { BOOK_DETAIL_QUERY_KEY } from './useBookDetails'
+
+export const useUpdateBook = (id: string | null) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    Publication,
+    PublicationApiError,
+    PublicationUpdate,
+    { previous?: Publication }
+  >({
+    mutationFn: (input) => {
+      if (!id) {
+        throw new PublicationApiError('Missing publication id', 'unknown')
+      }
+      return updateBook(id, input)
+    },
+    onMutate: async (input) => {
+      if (!id) return { previous: undefined }
+      const queryKey = BOOK_DETAIL_QUERY_KEY(id)
+      await queryClient.cancelQueries({ queryKey })
+      const previous = queryClient.getQueryData<Publication>(queryKey)
+      if (previous) {
+        const optimistic = applyPublicationUpdate(previous, input)
+        queryClient.setQueryData(queryKey, optimistic)
+      }
+      return { previous }
+    },
+    onError: (_error, _input, context) => {
+      if (!id) return
+      const queryKey = BOOK_DETAIL_QUERY_KEY(id)
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous)
+      }
+    },
+    onSuccess: (data) => {
+      if (!id) return
+      const queryKey = BOOK_DETAIL_QUERY_KEY(id)
+      queryClient.setQueryData(queryKey, data)
+    },
+    onSettled: () => {
+      if (!id) return
+      const queryKey = BOOK_DETAIL_QUERY_KEY(id)
+      queryClient.invalidateQueries({ queryKey })
+    },
+  })
+}

--- a/frontend/src/shared/types/global.d.ts
+++ b/frontend/src/shared/types/global.d.ts
@@ -22,6 +22,7 @@ declare module '*.svg' {
 type ImportMetaEnv = {
   readonly PUBLIC_MSW_FORCE_AUTH?: 'auto' | 'logged-in' | 'logged-out'
   readonly PUBLIC_API_BASE_URL?: string
+  readonly PUBLIC_BOOKS_API_MODE?: 'mock' | 'live'
   readonly PROD: boolean
 }
 interface ImportMeta {

--- a/frontend/tests/components/book/BookCard.test.tsx
+++ b/frontend/tests/components/book/BookCard.test.tsx
@@ -37,5 +37,8 @@ describe('BookCard', () => {
       screen.getByText((content) => content.includes('A, B, C +1'))
     ).toBeInTheDocument()
     expect(screen.getByText('booksPage.badge.seeking')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'booksPage.openDetail' })
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/tests/components/book/EditBookModal.test.tsx
+++ b/frontend/tests/components/book/EditBookModal.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@src/components/ui/toaster/Toaster', () => ({
+  Toaster: () => null,
+  showToast: vi.fn(),
+}))
+
+vi.mock('@src/utils/analytics', () => ({
+  track: vi.fn(),
+}))
+
+import { EditBookModal } from '@src/components/book/EditBookModal'
+import { showToast } from '@src/components/ui/toaster/Toaster'
+import { track } from '@src/utils/analytics'
+
+import { publicationStore } from '@mocks/handlers/books/fakers/publications.faker'
+
+import { renderWithProviders } from '../../test-utils'
+
+describe('EditBookModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders read-only state for guests', async () => {
+    publicationStore.ensure('guest-book', {
+      isOwner: false,
+      metadata: { title: 'Guest Title', author: 'Guest Author' },
+      images: [
+        { id: 'img', url: 'https://example.com/cover.jpg', alt: 'Cover' },
+      ],
+      notes: 'Notes',
+    })
+
+    renderWithProviders(
+      <EditBookModal bookId="guest-book" isOpen={true} onClose={vi.fn()} />
+    )
+
+    await screen.findByText('bookDetail.sections.details')
+
+    expect(screen.getByLabelText('bookDetail.fields.title')).toBeDisabled()
+    expect(
+      screen.queryByText('bookDetail.actions.save')
+    ).not.toBeInTheDocument()
+  })
+
+  it('allows owners to update fields and shows success feedback', async () => {
+    publicationStore.ensure('owner-book', {
+      isOwner: true,
+      metadata: { title: 'Owner Title', author: 'Owner Author' },
+      notes: 'Initial note',
+      images: [
+        { id: 'img', url: 'https://example.com/cover.jpg', alt: 'Cover' },
+      ],
+    })
+
+    renderWithProviders(
+      <EditBookModal bookId="owner-book" isOpen={true} onClose={vi.fn()} />
+    )
+
+    const notesInput = await screen.findByDisplayValue('Initial note')
+
+    fireEvent.change(notesInput, { target: { value: 'Updated note' } })
+
+    const saveButton = screen.getByText('bookDetail.actions.save')
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(
+        'bookDetail.messages.saved',
+        'success'
+      )
+    })
+
+    expect(track).toHaveBeenCalledWith(
+      'save_edit_book_success',
+      expect.objectContaining({ bookId: 'owner-book' })
+    )
+    expect(publicationStore.get('owner-book')?.notes).toBe('Updated note')
+  })
+})

--- a/frontend/tests/hooks/api/useBookDetails.test.tsx
+++ b/frontend/tests/hooks/api/useBookDetails.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { RELATIVE_API_ROUTES } from '@src/api/routes'
+import { useBookDetails } from '@src/hooks/api/useBookDetails'
+
+import { server } from '@mocks/server'
+
+import { createWrapper } from '../../test-utils'
+
+describe('useBookDetails', () => {
+  it('fetches book details successfully', async () => {
+    const { Wrapper } = createWrapper()
+    const { result } = renderHook(() => useBookDetails('test-book'), {
+      wrapper: Wrapper,
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.id).toBe('test-book')
+    expect(result.current.data?.metadata.title).toBeTruthy()
+  })
+
+  it('handles not found responses', async () => {
+    const notFoundRoute = RELATIVE_API_ROUTES.BOOKS.DETAIL('missing-book')
+    server.use(
+      http.get(notFoundRoute, () =>
+        HttpResponse.json({ message: 'Not found' }, { status: 404 })
+      )
+    )
+
+    const { Wrapper } = createWrapper()
+    const { result } = renderHook(() => useBookDetails('missing-book'), {
+      wrapper: Wrapper,
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.type).toBe('not_found')
+  })
+})

--- a/frontend/tests/hooks/api/useUpdateBook.test.tsx
+++ b/frontend/tests/hooks/api/useUpdateBook.test.tsx
@@ -1,0 +1,86 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { RELATIVE_API_ROUTES } from '@src/api/routes'
+import type { Publication } from '@src/api/books/publication.types'
+import { useBookDetails } from '@src/hooks/api/useBookDetails'
+import { useUpdateBook } from '@src/hooks/api/useUpdateBook'
+
+import { publicationStore } from '@mocks/handlers/books/fakers/publications.faker'
+import { server } from '@mocks/server'
+
+import { createWrapper } from '../../test-utils'
+
+describe('useUpdateBook', () => {
+  it('updates the publication and refreshes the cache', async () => {
+    publicationStore.ensure('editable-book', {
+      isOwner: true,
+      notes: 'Initial notes',
+    })
+
+    const { Wrapper, queryClient } = createWrapper()
+
+    const { result: detailsResult, unmount: unmountDetails } = renderHook(
+      () => useBookDetails('editable-book'),
+      { wrapper: Wrapper }
+    )
+
+    await waitFor(() => expect(detailsResult.current.isSuccess).toBe(true))
+    expect(detailsResult.current.data?.notes).toBe('Initial notes')
+
+    unmountDetails()
+
+    const { result } = renderHook(() => useUpdateBook('editable-book'), {
+      wrapper: Wrapper,
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({ notes: 'Updated notes' })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const updated = queryClient.getQueryData<Publication>([
+      'book',
+      'editable-book',
+    ])
+
+    if (!updated) {
+      throw new Error('Expected book details in cache after update')
+    }
+
+    expect(updated.notes).toBe('Updated notes')
+    expect(publicationStore.get('editable-book')?.notes).toBe('Updated notes')
+  })
+
+  it('surface forbidden errors', async () => {
+    publicationStore.ensure('readonly-book', {
+      isOwner: false,
+      notes: 'Notes',
+    })
+
+    const forbiddenRoute = RELATIVE_API_ROUTES.BOOKS.DETAIL('readonly-book')
+    server.use(
+      http.put(forbiddenRoute, () =>
+        HttpResponse.json(
+          { message: 'Forbidden' },
+          {
+            status: 403,
+          }
+        )
+      )
+    )
+
+    const { Wrapper } = createWrapper()
+    const { result } = renderHook(() => useUpdateBook('readonly-book'), {
+      wrapper: Wrapper,
+    })
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({ notes: 'Attempt' })
+      ).rejects.toMatchObject({ type: 'forbidden' })
+    })
+  })
+})

--- a/frontend/tests/test-utils.tsx
+++ b/frontend/tests/test-utils.tsx
@@ -4,6 +4,7 @@ import { ReactElement, ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 
 import { AuthProvider } from '@src/contexts/auth/AuthContext'
+import { BookDetailModalProvider } from '@src/contexts/book'
 import { ThemeProvider } from '@src/contexts/theme/ThemeContext'
 
 type WrapperOptions = {
@@ -22,7 +23,9 @@ export const createWrapper = (options?: WrapperOptions) => {
     <MemoryRouter initialEntries={options?.initialEntries}>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <ThemeProvider>{children}</ThemeProvider>
+          <ThemeProvider>
+            <BookDetailModalProvider>{children}</BookDetailModalProvider>
+          </ThemeProvider>
         </AuthProvider>
       </QueryClientProvider>
     </MemoryRouter>


### PR DESCRIPTION
## Summary
- add publication contracts, feature flag utilities, and detail/update API clients for books
- implement an accessible EditBookModal with editing workflows, analytics, and integration via BookDetailModalProvider/BookCard
- extend MSW mocks, translations, and tests to cover the new detail modal and optimistic update hooks

## Testing
- npx vitest run --coverage=false tests/hooks/api/useBookDetails.test.tsx tests/hooks/api/useUpdateBook.test.tsx tests/components/book/EditBookModal.test.tsx tests/components/book/BookCard.test.tsx
- npm run format:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e44249afe0832eac9840018151cf89