### PR TITLE
Add backend support for community book corners

### DIFF
--- a/backend/migrations/007_create_book_corners.sql
+++ b/backend/migrations/007_create_book_corners.sql
@@ -1,0 +1,17 @@
+CREATE TABLE book_corners (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  area TEXT,
+  location GEOGRAPHY(Point, 4326),
+  image_url TEXT,
+  created_by INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  approved BOOLEAN NOT NULL DEFAULT false,
+  recent_exchange_count INTEGER NOT NULL DEFAULT 0,
+  last_activity_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX book_corners_location_idx ON book_corners USING GIST (location);
+CREATE INDEX book_corners_approved_idx ON book_corners(approved);

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -746,6 +746,339 @@
         }
       }
     },
+    "/api/community/corners": {
+      "post": {
+        "summary": "Register a new community book corner",
+        "tags": ["Community"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "area": {
+                    "type": "string"
+                  },
+                  "imageUrl": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "object",
+                    "properties": {
+                      "latitude": {
+                        "type": "number"
+                      },
+                      "longitude": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Corner created in pending status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": ["string", "null"]
+                    },
+                    "area": {
+                      "type": ["string", "null"]
+                    },
+                    "imageUrl": {
+                      "type": ["string", "null"]
+                    },
+                    "location": {
+                      "oneOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "type": "object",
+                          "required": ["latitude", "longitude"],
+                          "properties": {
+                            "latitude": {
+                              "type": "number"
+                            },
+                            "longitude": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "activityStatus": {
+                      "type": "string",
+                      "enum": ["active", "quiet"]
+                    },
+                    "approved": {
+                      "type": "boolean"
+                    },
+                    "recentExchangeCount": {
+                      "type": "integer"
+                    },
+                    "lastActivityAt": {
+                      "type": ["string", "null"],
+                      "format": "date-time"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": ["pending", "approved"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/community/corners/nearby": {
+      "get": {
+        "summary": "List approved book corners near the authenticated user",
+        "tags": ["Community"],
+        "responses": {
+          "200": {
+            "description": "Array of nearby corners",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": ["string", "null"]
+                      },
+                      "area": {
+                        "type": ["string", "null"]
+                      },
+                      "imageUrl": {
+                        "type": ["string", "null"]
+                      },
+                      "location": {
+                        "oneOf": [
+                          {
+                            "type": "null"
+                          },
+                          {
+                            "type": "object",
+                            "required": ["latitude", "longitude"],
+                            "properties": {
+                              "latitude": {
+                                "type": "number"
+                              },
+                              "longitude": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "activityStatus": {
+                        "type": "string",
+                        "enum": ["active", "quiet"]
+                      },
+                      "approved": {
+                        "type": "boolean"
+                      },
+                      "recentExchangeCount": {
+                        "type": "integer"
+                      },
+                      "lastActivityAt": {
+                        "type": ["string", "null"],
+                        "format": "date-time"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "distanceKm": {
+                        "type": ["number", "null"]
+                      },
+                      "radiusKm": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Location required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/community/corners/map": {
+      "get": {
+        "summary": "Return approved corners for the community map",
+        "tags": ["Community"],
+        "responses": {
+          "200": {
+            "description": "Corner pins ready to render on map",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "introKey": {
+                      "type": "string"
+                    },
+                    "intro": {
+                      "type": "string"
+                    },
+                    "pins": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": ["string", "null"]
+                          },
+                          "area": {
+                            "type": ["string", "null"]
+                          },
+                          "imageUrl": {
+                            "type": ["string", "null"]
+                          },
+                          "location": {
+                            "oneOf": [
+                              {
+                                "type": "null"
+                              },
+                              {
+                                "type": "object",
+                                "required": ["latitude", "longitude"],
+                                "properties": {
+                                  "latitude": {
+                                    "type": "number"
+                                  },
+                                  "longitude": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          "activityStatus": {
+                            "type": "string",
+                            "enum": ["active", "quiet"]
+                          },
+                          "approved": {
+                            "type": "boolean"
+                          },
+                          "recentExchangeCount": {
+                            "type": "integer"
+                          },
+                          "lastActivityAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/books/{id}/verify": {
       "post": {
         "summary": "Verify a book",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import morgan from 'morgan';
 import booksRouter from './routes/books.js';
 import authRouter from './routes/auth.js';
 import userRouter from './routes/user.js';
+import communityRouter from './routes/community.js';
 import swaggerUi from 'swagger-ui-express';
 import swaggerSpec from './config/swagger.js';
 
@@ -25,8 +26,9 @@ app.get('/api/health', (_req, res) => {
 app.use('/api/books', booksRouter);
 app.use('/api/auth', authRouter);
 app.use('/api/user', userRouter);
+app.use('/api/community', communityRouter);
 
-// TODO(api-alignment): montar rutas para `/api/books/mine`, `/api/community/*` y
+// TODO(api-alignment): montar rutas pendientes como `/api/books/mine` y
 // `/api/contact/submit` cuando el backend cubra las necesidades del frontend y
 // dejemos de depender de mocks MSW.
 

--- a/backend/src/repositories/bookCornerRepository.ts
+++ b/backend/src/repositories/bookCornerRepository.ts
@@ -1,0 +1,216 @@
+import { query } from '../db.js';
+
+interface BookCornerRow {
+  id: number;
+  name: string;
+  description: string | null;
+  area: string | null;
+  image_url: string | null;
+  created_by: number;
+  approved: boolean;
+  recent_exchange_count: number;
+  last_activity_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  longitude: number | null;
+  latitude: number | null;
+  distance_meters?: number | string | null;
+}
+
+export interface BookCorner {
+  id: number;
+  name: string;
+  description: string | null;
+  area: string | null;
+  imageUrl: string | null;
+  createdBy: number;
+  approved: boolean;
+  recentExchangeCount: number;
+  lastActivityAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  location: { latitude: number; longitude: number } | null;
+  activityStatus: 'active' | 'quiet';
+}
+
+export interface BookCornerNearby extends BookCorner {
+  distanceMeters: number | null;
+}
+
+function toLocation(row: BookCornerRow): BookCorner['location'] {
+  if (row.longitude === null || row.latitude === null) {
+    return null;
+  }
+  return { latitude: row.latitude, longitude: row.longitude };
+}
+
+function computeActivityStatus(row: BookCornerRow): 'active' | 'quiet' {
+  if (row.recent_exchange_count > 0) {
+    return 'active';
+  }
+  if (!row.last_activity_at) {
+    return 'quiet';
+  }
+  const now = Date.now();
+  const lastActivity = row.last_activity_at.getTime();
+  const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+  return now - lastActivity <= THIRTY_DAYS_MS ? 'active' : 'quiet';
+}
+
+function rowToBookCorner(row: BookCornerRow): BookCorner {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    area: row.area,
+    imageUrl: row.image_url,
+    createdBy: row.created_by,
+    approved: row.approved,
+    recentExchangeCount: row.recent_exchange_count,
+    lastActivityAt: row.last_activity_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    location: toLocation(row),
+    activityStatus: computeActivityStatus(row),
+  };
+}
+
+export interface CreateBookCornerInput {
+  name: string;
+  description?: string | null;
+  area?: string | null;
+  imageUrl?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  createdBy: number;
+}
+
+export async function createBookCorner(
+  input: CreateBookCornerInput
+): Promise<BookCorner> {
+  const { rows } = await query<BookCornerRow>(
+    `INSERT INTO book_corners (
+      name,
+      description,
+      area,
+      image_url,
+      location,
+      created_by
+    )
+    VALUES (
+      $1,
+      $2,
+      $3,
+      $4,
+      CASE
+        WHEN $5::DOUBLE PRECISION IS NOT NULL AND $6::DOUBLE PRECISION IS NOT NULL THEN
+          ST_SetSRID(ST_MakePoint($5, $6), 4326)::geography
+        ELSE NULL
+      END,
+      $7
+    )
+    RETURNING *,
+      ST_X(location::geometry) AS longitude,
+      ST_Y(location::geometry) AS latitude`,
+    [
+      input.name,
+      input.description ?? null,
+      input.area ?? null,
+      input.imageUrl ?? null,
+      input.longitude ?? null,
+      input.latitude ?? null,
+      input.createdBy,
+    ]
+  );
+
+  return rowToBookCorner(rows[0]);
+}
+
+export interface ListNearbyCornersParams {
+  latitude: number;
+  longitude: number;
+  radiusKm: number;
+  limit?: number;
+}
+
+export async function listApprovedBookCornersNearby(
+  params: ListNearbyCornersParams
+): Promise<BookCornerNearby[]> {
+  const radiusMeters = params.radiusKm * 1000;
+  const limit = params.limit ?? 12;
+
+  const { rows } = await query<BookCornerRow>(
+    `SELECT
+      bc.*,
+      ST_X(bc.location::geometry) AS longitude,
+      ST_Y(bc.location::geometry) AS latitude,
+      ST_Distance(
+        bc.location,
+        ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography
+      ) AS distance_meters
+    FROM book_corners bc
+    WHERE
+      bc.approved = true
+      AND bc.location IS NOT NULL
+      AND ST_DWithin(
+        bc.location,
+        ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
+        $3
+      )
+    ORDER BY distance_meters ASC, bc.created_at DESC
+    LIMIT $4`,
+    [params.longitude, params.latitude, radiusMeters, limit]
+  );
+
+  return rows.map((row) => {
+    const rawDistance = row.distance_meters;
+    let distanceMeters: number | null;
+    if (typeof rawDistance === 'number') {
+      distanceMeters = rawDistance;
+    } else if (typeof rawDistance === 'string') {
+      const parsed = Number(rawDistance);
+      distanceMeters = Number.isNaN(parsed) ? null : parsed;
+    } else {
+      distanceMeters = null;
+    }
+
+    return {
+      ...rowToBookCorner(row),
+      distanceMeters,
+    };
+  });
+}
+
+export async function listApprovedBookCornersForMap(): Promise<BookCorner[]> {
+  const { rows } = await query<BookCornerRow>(
+    `SELECT
+      bc.*,
+      ST_X(bc.location::geometry) AS longitude,
+      ST_Y(bc.location::geometry) AS latitude
+    FROM book_corners bc
+    WHERE bc.approved = true
+    ORDER BY bc.updated_at DESC, bc.id ASC`
+  );
+
+  return rows.map((row) => rowToBookCorner(row));
+}
+
+export async function approveBookCorner(
+  id: number
+): Promise<BookCorner | null> {
+  const { rows } = await query<BookCornerRow>(
+    `UPDATE book_corners
+      SET approved = true,
+          updated_at = NOW()
+      WHERE id = $1
+      RETURNING *,
+        ST_X(location::geometry) AS longitude,
+        ST_Y(location::geometry) AS latitude`,
+    [id]
+  );
+
+  if (!rows[0]) {
+    return null;
+  }
+  return rowToBookCorner(rows[0]);
+}

--- a/backend/src/routes/community.ts
+++ b/backend/src/routes/community.ts
@@ -1,0 +1,250 @@
+import { Router } from 'express';
+import { authenticate, type AuthenticatedRequest } from '../middleware/auth.js';
+import {
+  createBookCorner,
+  listApprovedBookCornersNearby,
+  listApprovedBookCornersForMap,
+  type BookCorner,
+} from '../repositories/bookCornerRepository.js';
+
+const DEFAULT_NEARBY_RADIUS_KM = 10;
+const MAX_NEARBY_RESULTS = 20;
+
+const router = Router();
+
+interface CreateCornerPayload {
+  name: string;
+  description: string | null;
+  area: string | null;
+  imageUrl: string | null;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+function parseCreateCornerPayload(
+  body: unknown
+):
+  | { data: CreateCornerPayload }
+  | { error: { status: number; payload: { error: string; message: string } } } {
+  if (typeof body !== 'object' || body === null) {
+    return {
+      error: {
+        status: 400,
+        payload: {
+          error: 'InvalidPayload',
+          message: 'community.corners.errors.invalid_payload',
+        },
+      },
+    };
+  }
+
+  const raw = body as Record<string, unknown>;
+  const nameRaw = raw.name;
+  if (typeof nameRaw !== 'string' || nameRaw.trim().length === 0) {
+    return {
+      error: {
+        status: 400,
+        payload: {
+          error: 'MissingFields',
+          message: 'community.corners.errors.name_required',
+        },
+      },
+    };
+  }
+
+  const description =
+    typeof raw.description === 'string' && raw.description.trim().length > 0
+      ? raw.description.trim()
+      : null;
+
+  const areaSource =
+    typeof raw.area === 'string'
+      ? raw.area
+      : typeof raw.zone === 'string'
+        ? raw.zone
+        : null;
+  const area =
+    areaSource && areaSource.trim().length > 0 ? areaSource.trim() : null;
+
+  const imageSource =
+    typeof raw.imageUrl === 'string'
+      ? raw.imageUrl
+      : typeof raw.photoUrl === 'string'
+        ? raw.photoUrl
+        : null;
+  const imageUrl =
+    imageSource && imageSource.trim().length > 0 ? imageSource.trim() : null;
+
+  const locationRaw = (raw.location ?? {}) as Record<string, unknown>;
+  const latitudeCandidate =
+    typeof raw.latitude === 'number'
+      ? raw.latitude
+      : typeof locationRaw.latitude === 'number'
+        ? locationRaw.latitude
+        : null;
+  const longitudeCandidate =
+    typeof raw.longitude === 'number'
+      ? raw.longitude
+      : typeof locationRaw.longitude === 'number'
+        ? locationRaw.longitude
+        : null;
+
+  if (
+    (latitudeCandidate === null && longitudeCandidate !== null) ||
+    (latitudeCandidate !== null && longitudeCandidate === null)
+  ) {
+    return {
+      error: {
+        status: 400,
+        payload: {
+          error: 'InvalidFields',
+          message: 'community.corners.errors.incomplete_location',
+        },
+      },
+    };
+  }
+
+  let latitude: number | null = null;
+  let longitude: number | null = null;
+  if (latitudeCandidate !== null && longitudeCandidate !== null) {
+    if (
+      Number.isFinite(latitudeCandidate) &&
+      Number.isFinite(longitudeCandidate) &&
+      latitudeCandidate >= -90 &&
+      latitudeCandidate <= 90 &&
+      longitudeCandidate >= -180 &&
+      longitudeCandidate <= 180
+    ) {
+      latitude = latitudeCandidate;
+      longitude = longitudeCandidate;
+    } else {
+      return {
+        error: {
+          status: 400,
+          payload: {
+            error: 'InvalidFields',
+            message: 'community.corners.errors.invalid_location',
+          },
+        },
+      };
+    }
+  }
+
+  return {
+    data: {
+      name: nameRaw.trim(),
+      description,
+      area,
+      imageUrl,
+      latitude,
+      longitude,
+    },
+  };
+}
+
+function toPublicCorner(corner: BookCorner) {
+  return {
+    id: corner.id,
+    name: corner.name,
+    description: corner.description,
+    area: corner.area,
+    imageUrl: corner.imageUrl,
+    location: corner.location,
+    activityStatus: corner.activityStatus,
+    approved: corner.approved,
+    recentExchangeCount: corner.recentExchangeCount,
+    lastActivityAt: corner.lastActivityAt,
+    createdAt: corner.createdAt,
+    updatedAt: corner.updatedAt,
+  };
+}
+
+router.post(
+  '/corners',
+  authenticate,
+  async (req: AuthenticatedRequest, res) => {
+    if (!req.user) {
+      return res.status(401).json({
+        error: 'Unauthorized',
+        message: 'auth.errors.unauthorized',
+      });
+    }
+
+    const parsed = parseCreateCornerPayload(req.body);
+    if ('error' in parsed) {
+      return res.status(parsed.error.status).json(parsed.error.payload);
+    }
+
+    const { data } = parsed;
+    const corner = await createBookCorner({
+      name: data.name,
+      description: data.description,
+      area: data.area,
+      imageUrl: data.imageUrl,
+      latitude: data.latitude,
+      longitude: data.longitude,
+      createdBy: req.user.id,
+    });
+
+    return res.status(201).json({
+      ...toPublicCorner(corner),
+      status: corner.approved ? 'approved' : 'pending',
+    });
+  }
+);
+
+router.get(
+  '/corners/nearby',
+  authenticate,
+  async (req: AuthenticatedRequest, res) => {
+    if (!req.user) {
+      return res.status(401).json({
+        error: 'Unauthorized',
+        message: 'auth.errors.unauthorized',
+      });
+    }
+
+    if (!req.user.location) {
+      return res.status(400).json({
+        error: 'LocationRequired',
+        message: 'community.corners.errors.location_required',
+      });
+    }
+
+    const radiusKm =
+      typeof req.user.searchRadius === 'number' && req.user.searchRadius > 0
+        ? req.user.searchRadius
+        : DEFAULT_NEARBY_RADIUS_KM;
+
+    const corners = await listApprovedBookCornersNearby({
+      latitude: req.user.location.latitude,
+      longitude: req.user.location.longitude,
+      radiusKm,
+      limit: MAX_NEARBY_RESULTS,
+    });
+
+    return res.json(
+      corners.map((corner) => ({
+        ...toPublicCorner(corner),
+        distanceKm:
+          corner.distanceMeters !== null
+            ? Number((corner.distanceMeters / 1000).toFixed(2))
+            : null,
+        radiusKm,
+      }))
+    );
+  }
+);
+
+router.get('/corners/map', async (_req, res) => {
+  const corners = await listApprovedBookCornersForMap();
+  return res.json({
+    introKey: 'community.corners.map.description.default',
+    intro: 'Explora los Rincones de Libros activos en el mapa comunitario.',
+    pins: corners.map((corner) => ({
+      ...toPublicCorner(corner),
+    })),
+  });
+});
+
+export default router;

--- a/backend/tests/routes/community.api.test.ts
+++ b/backend/tests/routes/community.api.test.ts
@@ -1,0 +1,258 @@
+import request from 'supertest';
+import { beforeEach, afterEach, describe, expect, test } from 'vitest';
+import type { PoolClient } from 'pg';
+import app from '../../src/app.js';
+import { pool, setTestClient } from '../../src/db.js';
+import {
+  approveBookCorner,
+  createBookCorner,
+} from '../../src/repositories/bookCornerRepository.js';
+
+let client: PoolClient;
+
+beforeEach(async () => {
+  client = await pool.connect();
+  await client.query('BEGIN');
+  setTestClient(client);
+});
+
+afterEach(async () => {
+  await client.query('ROLLBACK');
+  client.release();
+  setTestClient(null);
+});
+
+async function registerAndLogin(email: string, password = 'Str0ng!Pass1') {
+  await request(app)
+    .post('/api/auth/register')
+    .send({
+      name: 'Test User',
+      email,
+      password,
+    })
+    .expect(201);
+
+  const loginRes = await request(app)
+    .post('/api/auth/login')
+    .send({ email, password })
+    .expect(200);
+
+  const cookie = loginRes.headers['set-cookie'][0];
+  const { rows } = await client.query<{ id: number }>(
+    'SELECT id FROM users WHERE email = $1',
+    [email]
+  );
+  return { cookie, userId: rows[0].id };
+}
+
+describe('POST /api/community/corners', () => {
+  test('requires authentication', async () => {
+    await request(app)
+      .post('/api/community/corners')
+      .send({ name: 'Sin auth' })
+      .expect(401);
+  });
+
+  test('creates a corner pending approval', async () => {
+    const { cookie, userId } = await registerAndLogin('corner@example.com');
+
+    const res = await request(app)
+      .post('/api/community/corners')
+      .set('Cookie', cookie)
+      .send({
+        name: 'Rincón Centro',
+        description: 'Intercambio en el centro cultural',
+        area: 'Centro',
+        imageUrl: 'https://example.com/corner.jpg',
+        location: {
+          latitude: -34.6037,
+          longitude: -58.3816,
+        },
+      })
+      .expect(201);
+
+    expect(res.body).toMatchObject({
+      name: 'Rincón Centro',
+      area: 'Centro',
+      description: 'Intercambio en el centro cultural',
+      imageUrl: 'https://example.com/corner.jpg',
+      status: 'pending',
+      approved: false,
+    });
+    expect(res.body.id).toBeGreaterThan(0);
+    expect(res.body.location).toEqual({
+      latitude: -34.6037,
+      longitude: -58.3816,
+    });
+
+    const { rows } = await client.query<{
+      name: string;
+      description: string | null;
+      area: string | null;
+      image_url: string | null;
+      approved: boolean;
+      created_by: number;
+      longitude: number | null;
+      latitude: number | null;
+    }>(
+      `SELECT
+        name,
+        description,
+        area,
+        image_url,
+        approved,
+        created_by,
+        ST_X(location::geometry) AS longitude,
+        ST_Y(location::geometry) AS latitude
+      FROM book_corners
+      WHERE id = $1`,
+      [res.body.id]
+    );
+
+    expect(rows[0]).toMatchObject({
+      name: 'Rincón Centro',
+      description: 'Intercambio en el centro cultural',
+      area: 'Centro',
+      image_url: 'https://example.com/corner.jpg',
+      approved: false,
+      created_by: userId,
+      longitude: -58.3816,
+      latitude: -34.6037,
+    });
+  });
+});
+
+describe('GET /api/community/corners/nearby', () => {
+  test('returns 400 when user has no location configured', async () => {
+    const { cookie } = await registerAndLogin('noloc@example.com');
+
+    const res = await request(app)
+      .get('/api/community/corners/nearby')
+      .set('Cookie', cookie)
+      .expect(400);
+
+    expect(res.body).toEqual({
+      error: 'LocationRequired',
+      message: 'community.corners.errors.location_required',
+    });
+  });
+
+  test('lists approved corners ordered by distance', async () => {
+    const { cookie, userId } = await registerAndLogin('nearby@example.com');
+
+    await client.query(
+      `UPDATE users
+       SET location = ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
+           search_radius = $3
+       WHERE id = $4`,
+      [-58.3816, -34.6037, 15, userId]
+    );
+
+    const closeCorner = await createBookCorner({
+      name: 'Rincón Obelisco',
+      description: 'Intercambio frente al Obelisco',
+      area: 'Microcentro',
+      imageUrl: 'https://example.com/obelisco.jpg',
+      latitude: -34.6037,
+      longitude: -58.3816,
+      createdBy: userId,
+    });
+    await approveBookCorner(closeCorner.id);
+
+    const fartherCorner = await createBookCorner({
+      name: 'Rincón San Telmo',
+      description: 'Biblioteca callejera',
+      area: 'San Telmo',
+      imageUrl: 'https://example.com/santelmo.jpg',
+      latitude: -34.6202,
+      longitude: -58.3719,
+      createdBy: userId,
+    });
+    await client.query(
+      'UPDATE book_corners SET recent_exchange_count = $1, last_activity_at = NOW() WHERE id = $2',
+      [3, fartherCorner.id]
+    );
+    await approveBookCorner(fartherCorner.id);
+
+    const res = await request(app)
+      .get('/api/community/corners/nearby')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0]).toMatchObject({
+      id: closeCorner.id,
+      name: 'Rincón Obelisco',
+      distanceKm: 0,
+      activityStatus: 'quiet',
+      radiusKm: 15,
+    });
+    expect(res.body[1]).toMatchObject({
+      id: fartherCorner.id,
+      name: 'Rincón San Telmo',
+      activityStatus: 'active',
+      recentExchangeCount: 3,
+    });
+    expect(res.body[1].distanceKm).toBeGreaterThan(0);
+    expect(res.body[1].distanceKm).toBeLessThan(3);
+  });
+});
+
+describe('GET /api/community/corners/map', () => {
+  test('returns empty pins when there are no approved corners', async () => {
+    const res = await request(app)
+      .get('/api/community/corners/map')
+      .expect(200);
+    expect(res.body).toEqual({
+      introKey: 'community.corners.map.description.default',
+      intro: 'Explora los Rincones de Libros activos en el mapa comunitario.',
+      pins: [],
+    });
+  });
+
+  test('returns approved corners ready for the map', async () => {
+    const { userId } = await registerAndLogin('map@example.com');
+
+    const first = await createBookCorner({
+      name: 'Rincón Palermo',
+      description: 'En la plaza principal',
+      area: 'Palermo',
+      imageUrl: 'https://example.com/palermo.jpg',
+      latitude: -34.5886,
+      longitude: -58.43,
+      createdBy: userId,
+    });
+    await approveBookCorner(first.id);
+
+    const second = await createBookCorner({
+      name: 'Rincón Villa Crespo',
+      description: null,
+      area: 'Villa Crespo',
+      imageUrl: null,
+      createdBy: userId,
+    });
+    await approveBookCorner(second.id);
+
+    const res = await request(app)
+      .get('/api/community/corners/map')
+      .expect(200);
+
+    expect(res.body.introKey).toBe('community.corners.map.description.default');
+    expect(res.body.pins).toHaveLength(2);
+    const ids = res.body.pins.map((pin: { id: number }) => pin.id);
+    expect(ids).toEqual(expect.arrayContaining([first.id, second.id]));
+
+    const palermoPin = res.body.pins.find(
+      (pin: { id: number }) => pin.id === first.id
+    );
+    expect(palermoPin).toMatchObject({
+      name: 'Rincón Palermo',
+      area: 'Palermo',
+      activityStatus: 'quiet',
+    });
+    expect(palermoPin.location).toEqual({
+      latitude: -34.5886,
+      longitude: -58.43,
+    });
+  });
+});

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -72,6 +72,7 @@ Feature 2.1 Alta y gestión de RdL
   - Actualización 2025-10-20: el paso de dirección ahora ofrece autocompletado con vista previa en mapa, fija latitud/longitud automáticamente y mantiene la preferencia de visibilidad sin exponer coordenadas manuales.
   - Actualización 2025-10-21: se completaron pruebas unitarias del servicio de geocodificación, handlers MSW y del paso de ubicación (autocomplete, errores, reinicio), recuperando la cobertura de ramas >85% y asegurando la regresión de privacidad.
   - Actualización 2025-10-22: se modularizó el paso de ubicación (inputs, carga de foto y consentimiento) y el modal completo via hooks dedicados para simplificar mantenimiento, agregando pruebas unitarias de navegación, errores y reinicio que elevan la cobertura de ramas y validan escenarios de teclado.
+  - Actualización 2025-10-24: el backend expone las rutas reales para registrar rincones, listar cercanos y poblar el mapa con datos aprobados, incluyendo migración de `book_corners`, validaciones i18n y pruebas de integración con PostGIS.
 - [ ] S-2.2 Estados de RdL (Activo / Pausa / Observación) (Should, E2; BR-12)
   - Éxito: pausa oculta de resultados temporalmente.
 - [ ] S-2.3 Verificación ligera de anfitrión (Could, E3; BR-14)


### PR DESCRIPTION
## Summary
- add a PostGIS-backed `book_corners` table and repository helpers for storing and moderating community spaces
- expose authenticated creation plus nearby and map listing endpoints for book corners and document them in the OpenAPI spec
- update the backlog entry for S-2.1 and cover the new endpoints with integration tests

## Testing
- npm run test:backend *(fails: Postgres service unavailable in environment)*
- npm run test:frontend *(terminated early after long runtime in this environment)*
- npm run format:backend
- npm run format:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e55e5245dc832e9945d76d3519a3f2