### PR TITLE
Add map APIs and geocoding integration

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -10,6 +10,325 @@
     }
   ],
   "paths": {
+    "/api/map": {
+      "get": {
+        "summary": "Retrieve map datasets for the requested bounding box",
+        "tags": ["Map"],
+        "parameters": [
+          {
+            "name": "north",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "number" },
+            "description": "Northern latitude of the bounding box"
+          },
+          {
+            "name": "south",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "number" },
+            "description": "Southern latitude of the bounding box"
+          },
+          {
+            "name": "east",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "number" },
+            "description": "Eastern longitude of the bounding box"
+          },
+          {
+            "name": "west",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "number" },
+            "description": "Western longitude of the bounding box"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Free text filter applied to corners and publications"
+          },
+          {
+            "name": "distanceKm",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "number" },
+            "description": "Maximum distance in kilometres for publications"
+          },
+          {
+            "name": "themes",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Comma separated list of themes to filter by"
+          },
+          {
+            "name": "openNow",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "boolean" },
+            "description": "If true, only corners currently open are returned"
+          },
+          {
+            "name": "recentActivity",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "boolean" },
+            "description": "If false, recent activity points are omitted"
+          },
+          {
+            "name": "layers",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Comma separated layers to include (corners, publications, activity)"
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Locale hint used for upstream providers"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Map payload with the requested datasets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["corners", "publications", "activity", "meta"],
+                  "properties": {
+                    "corners": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "name",
+                          "barrio",
+                          "city",
+                          "lat",
+                          "lon",
+                          "photos",
+                          "themes"
+                        ],
+                        "properties": {
+                          "id": { "type": "string" },
+                          "name": { "type": "string" },
+                          "barrio": { "type": "string" },
+                          "city": { "type": "string" },
+                          "lat": { "type": "number" },
+                          "lon": { "type": "number" },
+                          "lastSignalAt": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "photos": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                          },
+                          "rules": { "type": "string" },
+                          "referencePointLabel": { "type": "string" },
+                          "themes": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                          },
+                          "isOpenNow": { "type": "boolean" }
+                        }
+                      }
+                    },
+                    "publications": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "title",
+                          "authors",
+                          "type",
+                          "distanceKm",
+                          "cornerId"
+                        ],
+                        "properties": {
+                          "id": { "type": "string" },
+                          "title": { "type": "string" },
+                          "authors": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": ["offer", "want", "donation", "sale"]
+                          },
+                          "photo": { "type": "string" },
+                          "distanceKm": { "type": "number" },
+                          "cornerId": { "type": "string" },
+                          "lat": { "type": "number" },
+                          "lon": { "type": "number" }
+                        }
+                      }
+                    },
+                    "activity": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": ["id", "lat", "lon", "intensity"],
+                        "properties": {
+                          "id": { "type": "string" },
+                          "lat": { "type": "number" },
+                          "lon": { "type": "number" },
+                          "intensity": { "type": "number" }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "required": ["bbox", "generatedAt"],
+                      "properties": {
+                        "bbox": {
+                          "type": "object",
+                          "required": ["north", "south", "east", "west"],
+                          "properties": {
+                            "north": { "type": "number" },
+                            "south": { "type": "number" },
+                            "east": { "type": "number" },
+                            "west": { "type": "number" }
+                          }
+                        },
+                        "generatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid bounding box parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected error while generating map data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/map/geocode": {
+      "get": {
+        "summary": "Search address suggestions",
+        "tags": ["Map"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Query text to geocode"
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Locale hint forwarded to the geocoding provider"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of matching address suggestions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "id",
+                      "label",
+                      "street",
+                      "number",
+                      "coordinates"
+                    ],
+                    "properties": {
+                      "id": { "type": "string" },
+                      "label": { "type": "string" },
+                      "secondaryLabel": { "type": "string" },
+                      "street": { "type": "string" },
+                      "number": { "type": "string" },
+                      "postalCode": { "type": "string" },
+                      "coordinates": {
+                        "type": "object",
+                        "required": ["latitude", "longitude"],
+                        "properties": {
+                          "latitude": { "type": "number" },
+                          "longitude": { "type": "number" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing query parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream geocoding provider failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/register": {
       "post": {
         "summary": "Register a new user",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import morgan from 'morgan';
 import booksRouter from './routes/books.js';
 import authRouter from './routes/auth.js';
 import userRouter from './routes/user.js';
+import mapRouter from './routes/map.js';
 import swaggerUi from 'swagger-ui-express';
 import swaggerSpec from './config/swagger.js';
 
@@ -25,6 +26,7 @@ app.get('/api/health', (_req, res) => {
 app.use('/api/books', booksRouter);
 app.use('/api/auth', authRouter);
 app.use('/api/user', userRouter);
+app.use('/api/map', mapRouter);
 
 // TODO(api-alignment): montar rutas para `/api/books/mine`, `/api/community/*` y
 // `/api/contact/submit` cuando el backend cubra las necesidades del frontend y

--- a/backend/src/routes/map.ts
+++ b/backend/src/routes/map.ts
@@ -1,0 +1,152 @@
+import { Router } from 'express';
+
+import { fetchGeocodingSuggestions } from '../services/geocoding.js';
+import {
+  getMapData,
+  type MapBoundingBox,
+  type MapQuery,
+} from '../services/map.js';
+
+const router = Router();
+
+const parseNumberParam = (value: unknown): number | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed;
+};
+
+const parseBooleanParam = (value: unknown, defaultValue: boolean): boolean => {
+  if (typeof value === 'undefined') {
+    return defaultValue;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === '1' || normalized === 'true';
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return defaultValue;
+};
+
+const parseListParam = (value: unknown): string[] => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+};
+
+router.get('/geocode', async (req, res) => {
+  const rawQuery = req.query.q;
+  const query = Array.isArray(rawQuery) ? rawQuery[0] : rawQuery;
+  const trimmedQuery = (query ?? '').toString().trim();
+
+  if (trimmedQuery.length === 0) {
+    return res.status(400).json({
+      error: 'BadRequest',
+      message: 'map.errors.query_required',
+    });
+  }
+
+  const rawLocale = req.query.locale;
+  const locale = Array.isArray(rawLocale) ? rawLocale[0] : rawLocale;
+
+  try {
+    const suggestions = await fetchGeocodingSuggestions(
+      trimmedQuery,
+      typeof locale === 'string' ? locale : undefined
+    );
+    return res.json(suggestions);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    // eslint-disable-next-line no-console
+    console.error('Geocoding request failed', message);
+    return res.status(502).json({
+      error: 'GeocodingUnavailable',
+      message: 'map.errors.geocoding_unavailable',
+    });
+  }
+});
+
+router.get('/', (req, res) => {
+  const north = parseNumberParam(req.query.north);
+  const south = parseNumberParam(req.query.south);
+  const east = parseNumberParam(req.query.east);
+  const west = parseNumberParam(req.query.west);
+
+  if (north === null || south === null || east === null || west === null) {
+    return res.status(400).json({
+      error: 'BadRequest',
+      message: 'map.errors.bbox_required',
+    });
+  }
+
+  const bbox: MapBoundingBox = { north, south, east, west };
+
+  const searchRaw = req.query.search;
+  const search = Array.isArray(searchRaw)
+    ? (searchRaw[0]?.toString() ?? '')
+    : (searchRaw ?? '').toString();
+
+  const layersRaw = req.query.layers;
+  const layerList = parseListParam(layersRaw);
+  const allowedLayers = ['corners', 'publications', 'activity'] as const;
+  const normalizedLayers = (
+    layerList.length > 0 ? layerList : allowedLayers
+  ).filter((layer): layer is (typeof allowedLayers)[number] =>
+    allowedLayers.includes(layer as (typeof allowedLayers)[number])
+  );
+
+  const themes = parseListParam(req.query.themes);
+  const distanceParam = parseNumberParam(req.query.distanceKm);
+  const distanceKm = distanceParam ?? 0;
+  const openNow = parseBooleanParam(req.query.openNow, false);
+  const recentActivity = parseBooleanParam(req.query.recentActivity, true);
+
+  const mapQuery: MapQuery = {
+    bbox,
+    search,
+    layers: new Set(normalizedLayers),
+    filters: {
+      distanceKm,
+      themes,
+      openNow,
+      recentActivity,
+    },
+  };
+
+  if (mapQuery.layers.size === 0) {
+    mapQuery.layers = new Set(['corners', 'publications', 'activity']);
+  }
+
+  try {
+    const payload = getMapData(mapQuery);
+    return res.json(payload);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    // eslint-disable-next-line no-console
+    console.error('Map data generation failed', message);
+    return res.status(500).json({
+      error: 'MapGenerationFailed',
+      message: 'map.errors.map_unavailable',
+    });
+  }
+});
+
+export default router;

--- a/backend/src/services/geocoding.ts
+++ b/backend/src/services/geocoding.ts
@@ -1,0 +1,160 @@
+import { URL } from 'node:url';
+
+export interface GeocodingSuggestion {
+  id: string;
+  label: string;
+  secondaryLabel?: string;
+  street: string;
+  number: string;
+  postalCode?: string;
+  coordinates: {
+    latitude: number;
+    longitude: number;
+  };
+}
+
+interface NominatimAddress {
+  house_number?: string;
+  road?: string;
+  pedestrian?: string;
+  neighbourhood?: string;
+  suburb?: string;
+  city?: string;
+  town?: string;
+  village?: string;
+  state?: string;
+  region?: string;
+  postcode?: string;
+  country?: string;
+}
+
+interface NominatimResult {
+  place_id: number;
+  osm_id?: number;
+  display_name: string;
+  lat: string;
+  lon: string;
+  address?: NominatimAddress;
+}
+
+const GEOCODING_BASE_URL =
+  process.env.GEOCODING_BASE_URL ??
+  'https://nominatim.openstreetmap.org/search';
+
+const DEFAULT_USER_AGENT = 'EntreLibros/1.0 (geocoding@entrelibros)';
+
+const pickStreet = (address: NominatimAddress | undefined, label: string) => {
+  if (!address) {
+    return label;
+  }
+
+  const candidate =
+    address.road ??
+    address.pedestrian ??
+    address.neighbourhood ??
+    address.suburb ??
+    '';
+
+  if (candidate) {
+    return candidate;
+  }
+
+  return label.split(',')[0] ?? label;
+};
+
+const pickNumber = (address: NominatimAddress | undefined) => {
+  const number = address?.house_number?.trim();
+  return number && number.length > 0 ? number : 's/n';
+};
+
+const buildSecondaryLabel = (address: NominatimAddress | undefined) => {
+  if (!address) {
+    return undefined;
+  }
+
+  const locality =
+    address.city ?? address.town ?? address.village ?? address.suburb ?? '';
+  const region = address.state ?? address.region ?? '';
+  const country = address.country ?? '';
+
+  const parts = [locality, region, country]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part));
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  return parts.join(', ');
+};
+
+export const fetchGeocodingSuggestions = async (
+  query: string,
+  locale?: string
+): Promise<GeocodingSuggestion[]> => {
+  const url = new URL(GEOCODING_BASE_URL);
+  url.searchParams.set('q', query);
+  url.searchParams.set('format', 'jsonv2');
+  url.searchParams.set('addressdetails', '1');
+  url.searchParams.set('limit', '5');
+
+  if (locale && locale.trim().length > 0) {
+    url.searchParams.set('accept-language', locale.trim());
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': process.env.GEOCODING_USER_AGENT ?? DEFAULT_USER_AGENT,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Geocoding request failed with status ${response.status}`);
+  }
+
+  const payload = (await response.json()) as unknown;
+  if (!Array.isArray(payload)) {
+    throw new Error('Geocoding response was not an array');
+  }
+
+  const results: GeocodingSuggestion[] = payload
+    .filter((item): item is NominatimResult => {
+      if (!item || typeof item !== 'object') {
+        return false;
+      }
+
+      const candidate = item as Record<string, unknown>;
+      return (
+        typeof candidate.place_id === 'number' &&
+        typeof candidate.display_name === 'string' &&
+        typeof candidate.lat === 'string' &&
+        typeof candidate.lon === 'string'
+      );
+    })
+    .map((item) => {
+      const latitude = Number(item.lat);
+      const longitude = Number(item.lon);
+
+      if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+        throw new Error('Invalid coordinates returned by geocoding provider');
+      }
+
+      const street = pickStreet(item.address, item.display_name);
+      const number = pickNumber(item.address);
+
+      return {
+        id: `nominatim-${item.place_id}`,
+        label: `${street} ${number}`.trim(),
+        secondaryLabel: buildSecondaryLabel(item.address),
+        street,
+        number,
+        postalCode: item.address?.postcode,
+        coordinates: {
+          latitude,
+          longitude,
+        },
+      } satisfies GeocodingSuggestion;
+    });
+
+  return results;
+};

--- a/backend/src/services/map.ts
+++ b/backend/src/services/map.ts
@@ -1,0 +1,308 @@
+export interface MapBoundingBox {
+  north: number;
+  south: number;
+  east: number;
+  west: number;
+}
+
+export interface MapCornerPin {
+  id: string;
+  name: string;
+  barrio: string;
+  city: string;
+  lat: number;
+  lon: number;
+  lastSignalAt: string | null;
+  photos: string[];
+  rules?: string;
+  referencePointLabel?: string;
+  themes: string[];
+  isOpenNow?: boolean;
+}
+
+export type PublicationType = 'offer' | 'want' | 'donation' | 'sale';
+
+export interface MapPublicationPin {
+  id: string;
+  title: string;
+  authors: string[];
+  type: PublicationType;
+  photo?: string;
+  distanceKm: number;
+  cornerId: string;
+  lat?: number;
+  lon?: number;
+}
+
+export interface MapActivityPoint {
+  id: string;
+  lat: number;
+  lon: number;
+  intensity: number;
+}
+
+export interface MapFilters {
+  distanceKm: number;
+  themes: string[];
+  openNow: boolean;
+  recentActivity: boolean;
+}
+
+export interface MapQuery {
+  bbox: MapBoundingBox;
+  search: string;
+  filters: MapFilters;
+  layers: Set<'corners' | 'publications' | 'activity'>;
+}
+
+export interface MapResponseMeta {
+  bbox: MapBoundingBox;
+  generatedAt: string;
+}
+
+export interface MapResponse {
+  corners: MapCornerPin[];
+  publications: MapPublicationPin[];
+  activity: MapActivityPoint[];
+  meta: MapResponseMeta;
+}
+
+interface MapDataset {
+  corners: MapCornerPin[];
+  publications: MapPublicationPin[];
+  activity: MapActivityPoint[];
+  meta: MapResponseMeta;
+}
+
+const BASE_BOUNDS: MapBoundingBox = {
+  north: -34.54,
+  south: -34.72,
+  east: -58.36,
+  west: -58.55,
+};
+
+const DATASET: MapDataset = {
+  corners: [
+    {
+      id: 'corner-1',
+      name: 'Rincón Plaza Malabia',
+      barrio: 'Palermo',
+      city: 'Buenos Aires',
+      lat: -34.58802,
+      lon: -58.43044,
+      lastSignalAt: '2025-10-25T12:04:00.000Z',
+      photos: ['https://images.entrelibros.org/corners/palermo-01.jpg'],
+      rules: 'Traé un libro y llevate otro, dejá una nota para la comunidad.',
+      referencePointLabel: 'Junto al mástil central de la plaza',
+      themes: ['Infancias', 'Narrativa contemporánea'],
+      isOpenNow: true,
+    },
+    {
+      id: 'corner-2',
+      name: 'Bibliorincón Parque Patricios',
+      barrio: 'Parque Patricios',
+      city: 'Buenos Aires',
+      lat: -34.63421,
+      lon: -58.40438,
+      lastSignalAt: '2025-10-24T18:36:00.000Z',
+      photos: [
+        'https://images.entrelibros.org/corners/parque-patricios-01.jpg',
+      ],
+      referencePointLabel: 'Ingreso principal del Distrito Tecnológico',
+      themes: ['Historia', 'Ensayo'],
+      isOpenNow: false,
+    },
+    {
+      id: 'corner-3',
+      name: 'Club de Lectura Chacarita',
+      barrio: 'Chacarita',
+      city: 'Buenos Aires',
+      lat: -34.59561,
+      lon: -58.45673,
+      lastSignalAt: '2025-10-23T09:12:00.000Z',
+      photos: ['https://images.entrelibros.org/corners/chacarita-01.jpg'],
+      referencePointLabel: 'Dentro del centro cultural comunal',
+      themes: ['Poesía', 'Ciencia ficción'],
+      isOpenNow: true,
+    },
+    {
+      id: 'corner-4',
+      name: 'Rincón Barracas Sur',
+      barrio: 'Barracas',
+      city: 'Buenos Aires',
+      lat: -34.65628,
+      lon: -58.36792,
+      lastSignalAt: '2025-10-20T15:20:00.000Z',
+      photos: ['https://images.entrelibros.org/corners/barracas-01.jpg'],
+      themes: ['Infancias', 'Historia'],
+      isOpenNow: false,
+    },
+    {
+      id: 'corner-5',
+      name: 'Punto de Lectura Villa Crespo',
+      barrio: 'Villa Crespo',
+      city: 'Buenos Aires',
+      lat: -34.59983,
+      lon: -58.44126,
+      lastSignalAt: '2025-10-26T08:50:00.000Z',
+      photos: ['https://images.entrelibros.org/corners/villa-crespo-01.jpg'],
+      referencePointLabel: 'Terraza del centro barrial',
+      themes: ['Narrativa contemporánea', 'Poesía'],
+      isOpenNow: true,
+    },
+  ],
+  publications: [
+    {
+      id: 'pub-1',
+      title: 'Los años felices',
+      authors: ['Claudia Piñeiro'],
+      type: 'offer',
+      photo: 'https://images.entrelibros.org/publications/anios-felices.jpg',
+      distanceKm: 1.2,
+      cornerId: 'corner-1',
+      lat: -34.58901,
+      lon: -58.42812,
+    },
+    {
+      id: 'pub-2',
+      title: 'Rayuela',
+      authors: ['Julio Cortázar'],
+      type: 'donation',
+      photo: 'https://images.entrelibros.org/publications/rayuela.jpg',
+      distanceKm: 2.4,
+      cornerId: 'corner-3',
+    },
+    {
+      id: 'pub-3',
+      title: 'La invención de Morel',
+      authors: ['Adolfo Bioy Casares'],
+      type: 'sale',
+      photo: 'https://images.entrelibros.org/publications/invencion-morel.jpg',
+      distanceKm: 3.2,
+      cornerId: 'corner-2',
+      lat: -34.63311,
+      lon: -58.40157,
+    },
+    {
+      id: 'pub-4',
+      title: 'El Eternauta',
+      authors: ['Héctor Germán Oesterheld'],
+      type: 'want',
+      distanceKm: 4.8,
+      cornerId: 'corner-5',
+    },
+    {
+      id: 'pub-5',
+      title: 'Breve historia argentina',
+      authors: ['Felipe Pigna'],
+      type: 'offer',
+      distanceKm: 5.1,
+      cornerId: 'corner-4',
+    },
+    {
+      id: 'pub-6',
+      title: 'Mujer en tránsito',
+      authors: ['Gabriela Cabezón Cámara'],
+      type: 'donation',
+      photo: 'https://images.entrelibros.org/publications/mujer-transito.jpg',
+      distanceKm: 1.8,
+      cornerId: 'corner-5',
+    },
+  ],
+  activity: [
+    { id: 'activity-1', lat: -34.58621, lon: -58.43351, intensity: 4 },
+    { id: 'activity-2', lat: -34.63218, lon: -58.40711, intensity: 3 },
+    { id: 'activity-3', lat: -34.59774, lon: -58.44892, intensity: 5 },
+    { id: 'activity-4', lat: -34.66092, lon: -58.37385, intensity: 2 },
+    { id: 'activity-5', lat: -34.60481, lon: -58.43965, intensity: 4 },
+    { id: 'activity-6', lat: -34.61203, lon: -58.42112, intensity: 3 },
+  ],
+  meta: {
+    bbox: BASE_BOUNDS,
+    generatedAt: new Date().toISOString(),
+  },
+};
+
+const normalize = (value: string) => value.toLowerCase();
+
+const matchesSearch = (value: string, term: string) =>
+  normalize(value).includes(normalize(term));
+
+const matchesCornerSearch = (corner: MapCornerPin, term: string) =>
+  matchesSearch(corner.name, term) ||
+  matchesSearch(corner.barrio, term) ||
+  matchesSearch(corner.city, term);
+
+const matchesPublicationSearch = (
+  publication: MapPublicationPin,
+  term: string
+) =>
+  matchesSearch(publication.title, term) ||
+  publication.authors.some((author) => matchesSearch(author, term));
+
+const hasThemeOverlap = (themes: string[], filters: string[]) => {
+  if (filters.length === 0) {
+    return true;
+  }
+
+  const normalizedThemes = themes.map((theme) => normalize(theme));
+  return filters.some((filter) => normalizedThemes.includes(normalize(filter)));
+};
+
+const withinBounds = (corner: MapCornerPin, bbox: MapBoundingBox) =>
+  corner.lat <= bbox.north &&
+  corner.lat >= bbox.south &&
+  corner.lon <= bbox.east &&
+  corner.lon >= bbox.west;
+
+export const getMapData = (query: MapQuery): MapResponse => {
+  const searchTerm = query.search.trim().toLowerCase();
+  const themeFilters = query.filters.themes
+    .map((theme) => theme.trim())
+    .filter(Boolean);
+
+  const corners = DATASET.corners.filter((corner) => {
+    if (!withinBounds(corner, query.bbox)) {
+      return false;
+    }
+
+    const matchesTerm =
+      searchTerm.length === 0 || matchesCornerSearch(corner, searchTerm);
+    const matchesTheme = hasThemeOverlap(corner.themes, themeFilters);
+    const matchesOpen = !query.filters.openNow || Boolean(corner.isOpenNow);
+
+    return matchesTerm && matchesTheme && matchesOpen;
+  });
+
+  const cornerLookup = new Map(corners.map((corner) => [corner.id, corner]));
+
+  const publications = DATASET.publications.filter((publication) => {
+    const corner = cornerLookup.get(publication.cornerId);
+    if (!corner) {
+      return false;
+    }
+
+    const matchesTerm =
+      searchTerm.length === 0 ||
+      matchesPublicationSearch(publication, searchTerm);
+    const matchesTheme = hasThemeOverlap(corner.themes, themeFilters);
+    const matchesDistance =
+      Number.isFinite(query.filters.distanceKm) && query.filters.distanceKm > 0
+        ? publication.distanceKm <= query.filters.distanceKm
+        : true;
+
+    return matchesTerm && matchesTheme && matchesDistance;
+  });
+
+  const activity = query.filters.recentActivity ? DATASET.activity : [];
+
+  return {
+    corners: query.layers.has('corners') ? corners : [],
+    publications: query.layers.has('publications') ? publications : [],
+    activity: query.layers.has('activity') ? activity : [],
+    meta: {
+      bbox: query.bbox,
+      generatedAt: new Date().toISOString(),
+    },
+  };
+};

--- a/backend/tests/routes/map.api.test.ts
+++ b/backend/tests/routes/map.api.test.ts
@@ -1,0 +1,130 @@
+import request from 'supertest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import app from '../../src/app.js';
+
+describe('map geocoding endpoint', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('requires q parameter', async () => {
+    const response = await request(app).get('/api/map/geocode').expect(400);
+
+    expect(response.body).toEqual({
+      error: 'BadRequest',
+      message: 'map.errors.query_required',
+    });
+  });
+
+  test('returns mapped suggestions from geocoding provider', async () => {
+    const payload = [
+      {
+        place_id: 123,
+        display_name: 'Av. Corrientes 1234, Buenos Aires, Argentina',
+        lat: '-34.603722',
+        lon: '-58.381592',
+        address: {
+          road: 'Av. Corrientes',
+          house_number: '1234',
+          city: 'Buenos Aires',
+          state: 'Ciudad Autónoma de Buenos Aires',
+          postcode: '1043',
+          country: 'Argentina',
+        },
+      },
+    ];
+
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => payload,
+    } as unknown as Response);
+
+    const response = await request(app)
+      .get('/api/map/geocode')
+      .query({ q: 'Corrientes 1234', locale: 'es' })
+      .expect(200);
+
+    expect(response.body).toEqual([
+      {
+        id: 'nominatim-123',
+        label: 'Av. Corrientes 1234',
+        secondaryLabel:
+          'Buenos Aires, Ciudad Autónoma de Buenos Aires, Argentina',
+        street: 'Av. Corrientes',
+        number: '1234',
+        postalCode: '1043',
+        coordinates: {
+          latitude: -34.603722,
+          longitude: -58.381592,
+        },
+      },
+    ]);
+  });
+
+  test('handles upstream failure gracefully', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('network error'));
+
+    const response = await request(app)
+      .get('/api/map/geocode')
+      .query({ q: 'Corrientes' })
+      .expect(502);
+
+    expect(response.body).toEqual({
+      error: 'GeocodingUnavailable',
+      message: 'map.errors.geocoding_unavailable',
+    });
+  });
+});
+
+describe('map data endpoint', () => {
+  test('requires bounding box parameters', async () => {
+    const response = await request(app).get('/api/map').expect(400);
+
+    expect(response.body).toEqual({
+      error: 'BadRequest',
+      message: 'map.errors.bbox_required',
+    });
+  });
+
+  test('returns filtered data respecting layers', async () => {
+    const response = await request(app)
+      .get('/api/map')
+      .query({
+        north: -34.58,
+        south: -34.68,
+        east: -58.36,
+        west: -58.53,
+        search: 'Palermo',
+        distanceKm: 3,
+        themes: 'Infancias',
+        openNow: 'true',
+        recentActivity: 'false',
+        layers: 'corners,publications',
+      })
+      .expect(200);
+
+    expect(response.body.activity).toEqual([]);
+    expect(Array.isArray(response.body.corners)).toBe(true);
+    expect(response.body.corners.length).toBeGreaterThan(0);
+    expect(
+      response.body.corners.every((corner: { barrio: string }) =>
+        corner.barrio.includes('Palermo')
+      )
+    ).toBe(true);
+    expect(
+      response.body.publications.every(
+        (publication: { distanceKm: number }) => publication.distanceKm <= 3
+      )
+    ).toBe(true);
+    expect(response.body.meta).toMatchObject({
+      bbox: {
+        north: -34.58,
+        south: -34.68,
+        east: -58.36,
+        west: -58.53,
+      },
+    });
+    expect(typeof response.body.meta.generatedAt).toBe('string');
+  });
+});

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -82,6 +82,7 @@ Feature 2.2 Visibilidad y actividad
 - [~] S-2.4 Control de granularidad en mapa (barrio/ciudad) (Must, E1; BR-11)
   - Éxito: 100% de RdL respetan granularidad elegida.
   - Actualización 2025-10-16: el flujo de alta de RdL exige elegir visibilidad barrio/ciudad, persiste el consentimiento y refleja la selección en la revisión previa; resta propagarla al backend/mapa productivo.
+  - Actualización 2025-10-30: se publicaron los endpoints `/api/map` y `/api/map/geocode` conectados al frontend, con filtrado real por capas, geocodificación de Nominatim y dataset territorial inicial respetando los límites solicitados.
 - [ ] S-2.5 Señales de actividad en RdL (Should, E2; BR-13)
   - Éxito: 2 señales simples (visitas, contactos cercanos).
 


### PR DESCRIPTION
## Summary
- add a Nominatim-backed geocoding service and expose `/api/map/geocode` with validation
- serve `/api/map` datasets with layer, filter and bbox support aligned to the frontend contract
- document the new endpoints, cover them with tests, update the app wiring and backlog notes

## Testing
- npm run test:backend *(fails: PostgreSQL is not available in the container)*
- npm run test:frontend
- npm run format:backend
- npm run format:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e56d2b4af4832e8d836c40a51fa8a5