### PR TITLE
Add community analytics endpoints

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -19,77 +19,99 @@
             "name": "north",
             "in": "query",
             "required": true,
-            "schema": { "type": "number" },
+            "schema": {
+              "type": "number"
+            },
             "description": "Northern latitude of the bounding box"
           },
           {
             "name": "south",
             "in": "query",
             "required": true,
-            "schema": { "type": "number" },
+            "schema": {
+              "type": "number"
+            },
             "description": "Southern latitude of the bounding box"
           },
           {
             "name": "east",
             "in": "query",
             "required": true,
-            "schema": { "type": "number" },
+            "schema": {
+              "type": "number"
+            },
             "description": "Eastern longitude of the bounding box"
           },
           {
             "name": "west",
             "in": "query",
             "required": true,
-            "schema": { "type": "number" },
+            "schema": {
+              "type": "number"
+            },
             "description": "Western longitude of the bounding box"
           },
           {
             "name": "search",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Free text filter applied to corners and publications"
           },
           {
             "name": "distanceKm",
             "in": "query",
             "required": false,
-            "schema": { "type": "number" },
+            "schema": {
+              "type": "number"
+            },
             "description": "Maximum distance in kilometres for publications"
           },
           {
             "name": "themes",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Comma separated list of themes to filter by"
           },
           {
             "name": "openNow",
             "in": "query",
             "required": false,
-            "schema": { "type": "boolean" },
+            "schema": {
+              "type": "boolean"
+            },
             "description": "If true, only corners currently open are returned"
           },
           {
             "name": "recentActivity",
             "in": "query",
             "required": false,
-            "schema": { "type": "boolean" },
+            "schema": {
+              "type": "boolean"
+            },
             "description": "If false, recent activity points are omitted"
           },
           {
             "name": "layers",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Comma separated layers to include (corners, publications, activity)"
           },
           {
             "name": "locale",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Locale hint used for upstream providers"
           }
         ],
@@ -117,27 +139,49 @@
                           "themes"
                         ],
                         "properties": {
-                          "id": { "type": "string" },
-                          "name": { "type": "string" },
-                          "barrio": { "type": "string" },
-                          "city": { "type": "string" },
-                          "lat": { "type": "number" },
-                          "lon": { "type": "number" },
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "barrio": {
+                            "type": "string"
+                          },
+                          "city": {
+                            "type": "string"
+                          },
+                          "lat": {
+                            "type": "number"
+                          },
+                          "lon": {
+                            "type": "number"
+                          },
                           "lastSignalAt": {
                             "type": ["string", "null"],
                             "format": "date-time"
                           },
                           "photos": {
                             "type": "array",
-                            "items": { "type": "string" }
+                            "items": {
+                              "type": "string"
+                            }
                           },
-                          "rules": { "type": "string" },
-                          "referencePointLabel": { "type": "string" },
+                          "rules": {
+                            "type": "string"
+                          },
+                          "referencePointLabel": {
+                            "type": "string"
+                          },
                           "themes": {
                             "type": "array",
-                            "items": { "type": "string" }
+                            "items": {
+                              "type": "string"
+                            }
                           },
-                          "isOpenNow": { "type": "boolean" }
+                          "isOpenNow": {
+                            "type": "boolean"
+                          }
                         }
                       }
                     },
@@ -154,21 +198,37 @@
                           "cornerId"
                         ],
                         "properties": {
-                          "id": { "type": "string" },
-                          "title": { "type": "string" },
+                          "id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
                           "authors": {
                             "type": "array",
-                            "items": { "type": "string" }
+                            "items": {
+                              "type": "string"
+                            }
                           },
                           "type": {
                             "type": "string",
                             "enum": ["offer", "want", "donation", "sale"]
                           },
-                          "photo": { "type": "string" },
-                          "distanceKm": { "type": "number" },
-                          "cornerId": { "type": "string" },
-                          "lat": { "type": "number" },
-                          "lon": { "type": "number" }
+                          "photo": {
+                            "type": "string"
+                          },
+                          "distanceKm": {
+                            "type": "number"
+                          },
+                          "cornerId": {
+                            "type": "string"
+                          },
+                          "lat": {
+                            "type": "number"
+                          },
+                          "lon": {
+                            "type": "number"
+                          }
                         }
                       }
                     },
@@ -178,10 +238,18 @@
                         "type": "object",
                         "required": ["id", "lat", "lon", "intensity"],
                         "properties": {
-                          "id": { "type": "string" },
-                          "lat": { "type": "number" },
-                          "lon": { "type": "number" },
-                          "intensity": { "type": "number" }
+                          "id": {
+                            "type": "string"
+                          },
+                          "lat": {
+                            "type": "number"
+                          },
+                          "lon": {
+                            "type": "number"
+                          },
+                          "intensity": {
+                            "type": "number"
+                          }
                         }
                       }
                     },
@@ -193,10 +261,18 @@
                           "type": "object",
                           "required": ["north", "south", "east", "west"],
                           "properties": {
-                            "north": { "type": "number" },
-                            "south": { "type": "number" },
-                            "east": { "type": "number" },
-                            "west": { "type": "number" }
+                            "north": {
+                              "type": "number"
+                            },
+                            "south": {
+                              "type": "number"
+                            },
+                            "east": {
+                              "type": "number"
+                            },
+                            "west": {
+                              "type": "number"
+                            }
                           }
                         },
                         "generatedAt": {
@@ -217,8 +293,12 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": { "type": "string" },
-                    "message": { "type": "string" }
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -231,8 +311,12 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": { "type": "string" },
-                    "message": { "type": "string" }
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -250,14 +334,18 @@
             "name": "q",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Query text to geocode"
           },
           {
             "name": "locale",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Locale hint forwarded to the geocoding provider"
           }
         ],
@@ -278,18 +366,34 @@
                       "coordinates"
                     ],
                     "properties": {
-                      "id": { "type": "string" },
-                      "label": { "type": "string" },
-                      "secondaryLabel": { "type": "string" },
-                      "street": { "type": "string" },
-                      "number": { "type": "string" },
-                      "postalCode": { "type": "string" },
+                      "id": {
+                        "type": "string"
+                      },
+                      "label": {
+                        "type": "string"
+                      },
+                      "secondaryLabel": {
+                        "type": "string"
+                      },
+                      "street": {
+                        "type": "string"
+                      },
+                      "number": {
+                        "type": "string"
+                      },
+                      "postalCode": {
+                        "type": "string"
+                      },
                       "coordinates": {
                         "type": "object",
                         "required": ["latitude", "longitude"],
                         "properties": {
-                          "latitude": { "type": "number" },
-                          "longitude": { "type": "number" }
+                          "latitude": {
+                            "type": "number"
+                          },
+                          "longitude": {
+                            "type": "number"
+                          }
                         }
                       }
                     }
@@ -305,8 +409,12 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": { "type": "string" },
-                    "message": { "type": "string" }
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -319,8 +427,12 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": { "type": "string" },
-                    "message": { "type": "string" }
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -1118,8 +1230,395 @@
           }
         }
       }
+    },
+    "/api/community/stats": {
+      "get": {
+        "summary": "Retrieve aggregated community statistics",
+        "tags": ["Community"],
+        "responses": {
+          "200": {
+            "description": "Community KPIs and trends",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunityStats"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/community/feed": {
+      "get": {
+        "summary": "Retrieve the paginated community feed",
+        "tags": ["Community"],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            },
+            "description": "Page number starting from 0"
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 8
+            },
+            "description": "Number of items per page (max 20)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Community feed items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FeedItem"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "community.errors.invalid_pagination"
+          }
+        }
+      }
+    },
+    "/api/community/activity": {
+      "get": {
+        "summary": "List recent community activity avatars",
+        "tags": ["Community"],
+        "responses": {
+          "200": {
+            "description": "Recent activity participants",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/community/suggestions": {
+      "get": {
+        "summary": "Suggest community members to connect with",
+        "tags": ["Community"],
+        "responses": {
+          "200": {
+            "description": "Suggested community members",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SuggestionItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
-  "components": {},
+  "components": {
+    "schemas": {
+      "CommunityStats": {
+        "type": "object",
+        "properties": {
+          "kpis": {
+            "$ref": "#/components/schemas/CommunityStatsKpis"
+          },
+          "trendExchanges": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "trendNewBooks": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "topContributors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TopContributor"
+            }
+          },
+          "hotSearches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HotSearch"
+            }
+          },
+          "activeHousesMap": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MapPin"
+            }
+          }
+        },
+        "required": [
+          "kpis",
+          "trendExchanges",
+          "trendNewBooks",
+          "topContributors",
+          "hotSearches",
+          "activeHousesMap"
+        ]
+      },
+      "CommunityStatsKpis": {
+        "type": "object",
+        "properties": {
+          "exchanges": {
+            "type": "integer"
+          },
+          "activeHouses": {
+            "type": "integer"
+          },
+          "activeUsers": {
+            "type": "integer"
+          },
+          "booksPublished": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "exchanges",
+          "activeHouses",
+          "activeUsers",
+          "booksPublished"
+        ]
+      },
+      "TopContributor": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "metric": {
+            "type": "string",
+            "enum": ["exchanges", "books"]
+          },
+          "value": {
+            "type": "integer"
+          }
+        },
+        "required": ["username", "metric", "value"]
+      },
+      "HotSearch": {
+        "type": "object",
+        "properties": {
+          "term": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          }
+        },
+        "required": ["term", "count"]
+      },
+      "MapPin": {
+        "type": "object",
+        "properties": {
+          "top": {
+            "type": "string"
+          },
+          "left": {
+            "type": "string"
+          }
+        },
+        "required": ["top", "left"]
+      },
+      "FeedCorner": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "name"]
+      },
+      "FeedBase": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": "string",
+            "format": "uri"
+          },
+          "time": {
+            "type": "string"
+          },
+          "likes": {
+            "type": "integer"
+          },
+          "corner": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FeedCorner"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": ["id", "user", "avatar", "time", "likes"]
+      },
+      "BookFeedItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FeedBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["book"]
+              },
+              "title": {
+                "type": "string"
+              },
+              "author": {
+                "type": "string"
+              },
+              "cover": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": ["type", "title", "author", "cover"]
+          }
+        ]
+      },
+      "SaleFeedItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FeedBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["sale"]
+              },
+              "title": {
+                "type": "string"
+              },
+              "price": {
+                "type": "number"
+              },
+              "condition": {
+                "type": "string"
+              },
+              "cover": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": ["type", "title", "price", "condition", "cover"]
+          }
+        ]
+      },
+      "SeekingFeedItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FeedBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["seeking"]
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": ["type", "title"]
+          }
+        ]
+      },
+      "FeedItem": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BookFeedItem"
+          },
+          {
+            "$ref": "#/components/schemas/SaleFeedItem"
+          },
+          {
+            "$ref": "#/components/schemas/SeekingFeedItem"
+          }
+        ]
+      },
+      "ActivityItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": ["id", "user", "avatar"]
+      },
+      "SuggestionItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": ["id", "user", "avatar"]
+      }
+    }
+  },
   "tags": []
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import booksRouter from './routes/books.js';
 import authRouter from './routes/auth.js';
 import userRouter from './routes/user.js';
 import mapRouter from './routes/map.js';
+import communityRouter from './routes/community.js';
 import swaggerUi from 'swagger-ui-express';
 import swaggerSpec from './config/swagger.js';
 
@@ -27,6 +28,7 @@ app.use('/api/books', booksRouter);
 app.use('/api/auth', authRouter);
 app.use('/api/user', userRouter);
 app.use('/api/map', mapRouter);
+app.use('/api/community', communityRouter);
 
 // TODO(api-alignment): montar rutas para `/api/books/mine`, `/api/community/*` y
 // `/api/contact/submit` cuando el backend cubra las necesidades del frontend y

--- a/backend/src/routes/community.ts
+++ b/backend/src/routes/community.ts
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+
+import {
+  getCommunityActivity,
+  getCommunityStats,
+  getCommunitySuggestions,
+} from '../services/communityStats.js';
+import { getCommunityFeed } from '../services/communityFeed.js';
+
+const router = Router();
+
+router.get('/stats', (_req, res) => {
+  const stats = getCommunityStats();
+  res.json(stats);
+});
+
+router.get('/feed', (req, res) => {
+  const rawPage = req.query.page;
+  const rawSize = req.query.size;
+
+  const page = rawPage === undefined ? 0 : Number(rawPage);
+  const size = rawSize === undefined ? 8 : Number(rawSize);
+
+  if (
+    !Number.isInteger(page) ||
+    page < 0 ||
+    !Number.isInteger(size) ||
+    size <= 0
+  ) {
+    return res.status(400).json({
+      error: 'BadRequest',
+      message: 'community.errors.invalid_pagination',
+    });
+  }
+
+  const clampedSize = Math.min(size, 20);
+  const feed = getCommunityFeed({ page, size: clampedSize });
+  res.json(feed);
+});
+
+router.get('/activity', (_req, res) => {
+  const activity = getCommunityActivity();
+  res.json(activity);
+});
+
+router.get('/suggestions', (_req, res) => {
+  const suggestions = getCommunitySuggestions();
+  res.json(suggestions);
+});
+
+export default router;

--- a/backend/src/services/communityFeed.ts
+++ b/backend/src/services/communityFeed.ts
@@ -1,0 +1,213 @@
+import {
+  COMMUNITY_CORNERS,
+  COMMUNITY_LISTINGS,
+  COMMUNITY_REFERENCE_DATE,
+  COMMUNITY_USERS,
+  type CommunityListing,
+} from './communityStats.js';
+
+export type FeedItem = BookFeedItem | SaleFeedItem | SeekingFeedItem;
+
+export interface FeedBase {
+  id: string;
+  user: string;
+  avatar: string;
+  time: string;
+  likes: number;
+  corner?: FeedCorner;
+}
+
+export interface FeedCorner {
+  id: string;
+  name: string;
+}
+
+export interface BookFeedItem extends FeedBase {
+  type: 'book';
+  title: string;
+  author: string;
+  cover: string;
+}
+
+export interface SaleFeedItem extends FeedBase {
+  type: 'sale';
+  title: string;
+  price: number;
+  condition: string;
+  cover: string;
+}
+
+export interface SeekingFeedItem extends FeedBase {
+  type: 'seeking';
+  title: string;
+}
+
+export interface CommunityFeedOptions {
+  page: number;
+  size: number;
+}
+
+const cornersById = new Map(
+  COMMUNITY_CORNERS.map((corner) => [corner.id, corner] as const)
+);
+
+const usersById = new Map(
+  COMMUNITY_USERS.map((user) => [user.id, user] as const)
+);
+
+let cachedFeed: FeedItem[] | null = null;
+
+export function getCommunityFeed(options: CommunityFeedOptions): FeedItem[] {
+  if (!cachedFeed) {
+    cachedFeed = buildFeed();
+  }
+
+  const { page, size } = options;
+  const start = page * size;
+  if (start >= cachedFeed.length) {
+    return [];
+  }
+
+  return cachedFeed
+    .slice(start, start + size)
+    .map((item) => cloneFeedItem(item));
+}
+
+function buildFeed(): FeedItem[] {
+  return COMMUNITY_LISTINGS.slice()
+    .sort((a, b) => {
+      const diff =
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      if (diff !== 0) {
+        return diff;
+      }
+      return a.id.localeCompare(b.id, 'es');
+    })
+    .map((listing) => toFeedItem(listing))
+    .filter((item): item is FeedItem => item !== null);
+}
+
+function toFeedItem(listing: CommunityListing): FeedItem | null {
+  const user = usersById.get(listing.userId);
+  if (!user) {
+    return null;
+  }
+
+  const base: FeedBase = {
+    id: listing.id,
+    user: user.displayName,
+    avatar: user.avatar,
+    time: relativeTimeFromReference(listing.createdAt),
+    likes: listing.likes,
+    corner: listing.cornerId ? toFeedCorner(listing.cornerId) : undefined,
+  };
+
+  if (listing.category === 'book' && listing.author && listing.cover) {
+    return {
+      ...base,
+      type: 'book',
+      title: listing.title,
+      author: listing.author,
+      cover: listing.cover,
+    };
+  }
+
+  if (
+    listing.category === 'sale' &&
+    listing.cover &&
+    listing.author &&
+    typeof listing.price === 'number' &&
+    typeof listing.condition === 'string'
+  ) {
+    return {
+      ...base,
+      type: 'sale',
+      title: listing.title,
+      price: listing.price,
+      condition: listing.condition,
+      cover: listing.cover,
+    };
+  }
+
+  if (listing.category === 'seeking') {
+    return {
+      ...base,
+      type: 'seeking',
+      title: listing.title,
+    };
+  }
+
+  return null;
+}
+
+function toFeedCorner(cornerId: string): FeedCorner | undefined {
+  const corner = cornersById.get(cornerId);
+  if (!corner) {
+    return undefined;
+  }
+  return { id: corner.id, name: corner.name };
+}
+
+function relativeTimeFromReference(createdAt: string): string {
+  const created = new Date(createdAt).getTime();
+  const reference = COMMUNITY_REFERENCE_DATE.getTime();
+  const diffMinutes = Math.max(
+    1,
+    Math.floor((reference - created) / (60 * 1000))
+  );
+
+  if (diffMinutes < 60) {
+    return `hace ${diffMinutes} min`;
+  }
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) {
+    return `hace ${diffHours} h`;
+  }
+
+  const diffDays = Math.floor(diffHours / 24);
+  return `hace ${diffDays} d`;
+}
+
+function cloneFeedItem(item: FeedItem): FeedItem {
+  const base = cloneFeedBase(item);
+  switch (item.type) {
+    case 'book':
+      return {
+        ...base,
+        type: 'book',
+        title: item.title,
+        author: item.author,
+        cover: item.cover,
+      };
+    case 'sale':
+      return {
+        ...base,
+        type: 'sale',
+        title: item.title,
+        price: item.price,
+        condition: item.condition,
+        cover: item.cover,
+      };
+    case 'seeking':
+      return {
+        ...base,
+        type: 'seeking',
+        title: item.title,
+      };
+  }
+
+  const _exhaustiveCheck: never = item;
+  return _exhaustiveCheck;
+}
+
+function cloneFeedBase(item: FeedBase): FeedBase {
+  return {
+    id: item.id,
+    user: item.user,
+    avatar: item.avatar,
+    time: item.time,
+    likes: item.likes,
+    corner: item.corner ? { ...item.corner } : undefined,
+  };
+}

--- a/backend/src/services/communityStats.ts
+++ b/backend/src/services/communityStats.ts
@@ -1,0 +1,568 @@
+export interface CommunityUserProfile {
+  id: string;
+  username: string;
+  displayName: string;
+  avatar: string;
+  languages: string[];
+  city: string;
+  barrio: string;
+  lastActiveAt: string;
+  exchangesCompleted: number;
+  booksPublished: number;
+}
+
+export interface CommunityCorner {
+  id: string;
+  name: string;
+  barrio: string;
+  city: string;
+  active: boolean;
+  map: { top: number; left: number };
+}
+
+export type CommunityListingCategory = 'book' | 'sale' | 'seeking';
+
+export interface CommunityListing {
+  id: string;
+  userId: string;
+  cornerId: string | null;
+  title: string;
+  author?: string;
+  cover?: string;
+  price?: number;
+  condition?: string;
+  category: CommunityListingCategory;
+  likes: number;
+  createdAt: string;
+  searchTags: string[];
+}
+
+export interface CommunityStatsKpis {
+  exchanges: number;
+  activeHouses: number;
+  activeUsers: number;
+  booksPublished: number;
+}
+
+export type TopContributorMetric = 'exchanges' | 'books';
+
+export interface TopContributor {
+  username: string;
+  metric: TopContributorMetric;
+  value: number;
+}
+
+export interface HotSearch {
+  term: string;
+  count: number;
+}
+
+export interface MapPin {
+  top: string;
+  left: string;
+}
+
+export interface CommunityStats {
+  kpis: CommunityStatsKpis;
+  trendExchanges: number[];
+  trendNewBooks: number[];
+  topContributors: TopContributor[];
+  hotSearches: HotSearch[];
+  activeHousesMap: MapPin[];
+}
+
+export interface ActivityItem {
+  id: string;
+  user: string;
+  avatar: string;
+}
+
+export interface SuggestionItem {
+  id: string;
+  user: string;
+  avatar: string;
+}
+
+export const COMMUNITY_REFERENCE_DATE = new Date('2025-11-01T12:00:00.000Z');
+
+const USERS: readonly CommunityUserProfile[] = [
+  {
+    id: 'user-1',
+    username: '@sofi',
+    displayName: 'Sofía M.',
+    avatar: 'https://images.entrelibros.org/avatars/sofia-m.png',
+    languages: ['es', 'en'],
+    city: 'Buenos Aires',
+    barrio: 'Palermo',
+    lastActiveAt: '2025-10-30T18:45:00.000Z',
+    exchangesCompleted: 18,
+    booksPublished: 12,
+  },
+  {
+    id: 'user-2',
+    username: '@marcos',
+    displayName: 'Marcos R.',
+    avatar: 'https://images.entrelibros.org/avatars/marcos-r.png',
+    languages: ['es'],
+    city: 'Buenos Aires',
+    barrio: 'Chacarita',
+    lastActiveAt: '2025-10-30T16:12:00.000Z',
+    exchangesCompleted: 21,
+    booksPublished: 9,
+  },
+  {
+    id: 'user-3',
+    username: '@lucia',
+    displayName: 'Lucía F.',
+    avatar: 'https://images.entrelibros.org/avatars/lucia-f.png',
+    languages: ['es', 'fr'],
+    city: 'Buenos Aires',
+    barrio: 'Villa Crespo',
+    lastActiveAt: '2025-10-28T22:05:00.000Z',
+    exchangesCompleted: 9,
+    booksPublished: 14,
+  },
+  {
+    id: 'user-4',
+    username: '@aylen',
+    displayName: 'Aylén P.',
+    avatar: 'https://images.entrelibros.org/avatars/aylen-p.png',
+    languages: ['es', 'pt'],
+    city: 'Buenos Aires',
+    barrio: 'Caballito',
+    lastActiveAt: '2025-10-26T11:40:00.000Z',
+    exchangesCompleted: 15,
+    booksPublished: 6,
+  },
+  {
+    id: 'user-5',
+    username: '@diego',
+    displayName: 'Diego L.',
+    avatar: 'https://images.entrelibros.org/avatars/diego-l.png',
+    languages: ['es', 'en'],
+    city: 'Buenos Aires',
+    barrio: 'Almagro',
+    lastActiveAt: '2025-10-15T08:10:00.000Z',
+    exchangesCompleted: 6,
+    booksPublished: 4,
+  },
+  {
+    id: 'user-6',
+    username: '@valen',
+    displayName: 'Valen C.',
+    avatar: 'https://images.entrelibros.org/avatars/valen-c.png',
+    languages: ['es', 'en'],
+    city: 'La Plata',
+    barrio: 'Tolosa',
+    lastActiveAt: '2025-09-29T19:33:00.000Z',
+    exchangesCompleted: 4,
+    booksPublished: 5,
+  },
+] as const;
+
+const CORNERS: readonly CommunityCorner[] = [
+  {
+    id: 'corner-1',
+    name: 'Rincón Plaza Malabia',
+    barrio: 'Palermo',
+    city: 'Buenos Aires',
+    active: true,
+    map: { top: 42, left: 58 },
+  },
+  {
+    id: 'corner-2',
+    name: 'Bibliorincón Parque Patricios',
+    barrio: 'Parque Patricios',
+    city: 'Buenos Aires',
+    active: true,
+    map: { top: 68, left: 35 },
+  },
+  {
+    id: 'corner-3',
+    name: 'Club de Lectura Chacarita',
+    barrio: 'Chacarita',
+    city: 'Buenos Aires',
+    active: true,
+    map: { top: 51, left: 46 },
+  },
+  {
+    id: 'corner-4',
+    name: 'Rincón Barracas Sur',
+    barrio: 'Barracas',
+    city: 'Buenos Aires',
+    active: false,
+    map: { top: 79, left: 62 },
+  },
+  {
+    id: 'corner-5',
+    name: 'Punto de Lectura Villa Crespo',
+    barrio: 'Villa Crespo',
+    city: 'Buenos Aires',
+    active: true,
+    map: { top: 47, left: 41 },
+  },
+  {
+    id: 'corner-6',
+    name: 'Rincón Colegiales',
+    barrio: 'Colegiales',
+    city: 'Buenos Aires',
+    active: true,
+    map: { top: 44, left: 53 },
+  },
+] as const;
+
+const LISTINGS: readonly CommunityListing[] = [
+  {
+    id: 'listing-1',
+    userId: 'user-1',
+    cornerId: 'corner-1',
+    title: 'Los años felices',
+    author: 'Claudia Piñeiro',
+    cover: 'https://images.entrelibros.org/books/anios-felices.jpg',
+    category: 'book',
+    likes: 42,
+    createdAt: '2025-10-30T17:20:00.000Z',
+    searchTags: ['fantasia juvenil', 'club de lectura', 'thriller'],
+  },
+  {
+    id: 'listing-2',
+    userId: 'user-2',
+    cornerId: 'corner-2',
+    title: 'La invención de la naturaleza',
+    author: 'Andrea Wulf',
+    cover: 'https://images.entrelibros.org/books/invencion-naturaleza.jpg',
+    price: 12000,
+    condition: 'como nuevo',
+    category: 'sale',
+    likes: 35,
+    createdAt: '2025-10-30T15:00:00.000Z',
+    searchTags: ['ensayo feminista', 'naturaleza', 'biografia'],
+  },
+  {
+    id: 'listing-3',
+    userId: 'user-3',
+    cornerId: 'corner-5',
+    title: 'Busco: Antología Poesía Mapuche',
+    category: 'seeking',
+    likes: 21,
+    createdAt: '2025-10-29T20:10:00.000Z',
+    searchTags: ['poesia contemporanea', 'traduccion', 'lenguas originarias'],
+  },
+  {
+    id: 'listing-4',
+    userId: 'user-4',
+    cornerId: 'corner-3',
+    title: 'El jardín secreto',
+    author: 'Frances Hodgson Burnett',
+    cover: 'https://images.entrelibros.org/books/jardin-secreto.jpg',
+    category: 'book',
+    likes: 29,
+    createdAt: '2025-10-28T13:45:00.000Z',
+    searchTags: ['infancias', 'aventura', 'clásicos'],
+  },
+  {
+    id: 'listing-5',
+    userId: 'user-1',
+    cornerId: 'corner-1',
+    title: 'Astroguía del Cono Sur',
+    author: 'María Pía López',
+    cover: 'https://images.entrelibros.org/books/astroguia-conosur.jpg',
+    price: 6800,
+    condition: 'usado',
+    category: 'sale',
+    likes: 18,
+    createdAt: '2025-10-27T10:05:00.000Z',
+    searchTags: ['astro', 'ensayo feminista', 'club de lectura'],
+  },
+  {
+    id: 'listing-6',
+    userId: 'user-2',
+    cornerId: 'corner-6',
+    title: 'Invasión 2040',
+    author: 'Liliana Bodoc',
+    cover: 'https://images.entrelibros.org/books/invasion-2040.jpg',
+    category: 'book',
+    likes: 24,
+    createdAt: '2025-10-26T18:30:00.000Z',
+    searchTags: [
+      'ciencia ficcion argentina',
+      'distopia latina',
+      'fantasia juvenil',
+    ],
+  },
+  {
+    id: 'listing-7',
+    userId: 'user-5',
+    cornerId: null,
+    title: 'Busco: Historias mínimas del AMBA',
+    category: 'seeking',
+    likes: 11,
+    createdAt: '2025-10-25T09:15:00.000Z',
+    searchTags: [
+      'cronica urbana',
+      'historia local',
+      'ciencia ficcion argentina',
+    ],
+  },
+  {
+    id: 'listing-8',
+    userId: 'user-3',
+    cornerId: 'corner-5',
+    title: 'Economías para el bien común',
+    author: 'Christian Felber',
+    cover: 'https://images.entrelibros.org/books/economias-bien-comun.jpg',
+    price: 5400,
+    condition: 'como nuevo',
+    category: 'sale',
+    likes: 16,
+    createdAt: '2025-10-24T16:00:00.000Z',
+    searchTags: ['economia solidaria', 'ensayo feminista', 'naturaleza'],
+  },
+  {
+    id: 'listing-9',
+    userId: 'user-4',
+    cornerId: 'corner-3',
+    title: 'La trama celeste',
+    author: 'Adolfo Bioy Casares',
+    cover: 'https://images.entrelibros.org/books/trama-celeste.jpg',
+    category: 'book',
+    likes: 14,
+    createdAt: '2025-10-23T11:30:00.000Z',
+    searchTags: ['ciencia ficcion argentina', 'clásicos', 'fantasia juvenil'],
+  },
+  {
+    id: 'listing-10',
+    userId: 'user-6',
+    cornerId: 'corner-4',
+    title: 'Crónicas del Río de la Plata',
+    author: 'Eduardo Belgrano Rawson',
+    cover: 'https://images.entrelibros.org/books/cronicas-rio-plata.jpg',
+    category: 'book',
+    likes: 9,
+    createdAt: '2025-10-22T18:20:00.000Z',
+    searchTags: ['historia local', 'cronica urbana'],
+  },
+] as const;
+
+const POPULAR_SEARCH_SEED: ReadonlyArray<{ term: string; weight: number }> = [
+  { term: 'ensayo feminista', weight: 2 },
+  { term: 'fantasia juvenil', weight: 1 },
+  { term: 'ciencia ficcion argentina', weight: 0 },
+  { term: 'club de lectura', weight: 1 },
+  { term: 'historia local', weight: 0 },
+];
+
+const TREND_EXCHANGES = [36, 42, 45, 51, 58, 64, 72];
+const TREND_NEW_BOOKS = [18, 21, 24, 22, 27, 29, 33];
+
+let cachedStats: CommunityStats | null = null;
+let cachedActivity: ActivityItem[] | null = null;
+let cachedSuggestions: SuggestionItem[] | null = null;
+
+export const COMMUNITY_USERS: readonly CommunityUserProfile[] = USERS;
+export const COMMUNITY_CORNERS: readonly CommunityCorner[] = CORNERS;
+export const COMMUNITY_LISTINGS: readonly CommunityListing[] = LISTINGS;
+
+export function getCommunityStats(): CommunityStats {
+  if (!cachedStats) {
+    cachedStats = buildCommunityStats();
+  }
+  return cloneStats(cachedStats);
+}
+
+export function getCommunityActivity(): ActivityItem[] {
+  if (!cachedActivity) {
+    cachedActivity = buildCommunityActivity();
+  }
+  return cachedActivity.map((item) => ({ ...item }));
+}
+
+export function getCommunitySuggestions(): SuggestionItem[] {
+  if (!cachedSuggestions) {
+    cachedSuggestions = buildCommunitySuggestions();
+  }
+  return cachedSuggestions.map((item) => ({ ...item }));
+}
+
+function buildCommunityStats(): CommunityStats {
+  const exchanges = USERS.reduce(
+    (total, profile) => total + profile.exchangesCompleted,
+    0
+  );
+
+  const activeCutoff = new Date(COMMUNITY_REFERENCE_DATE.getTime());
+  activeCutoff.setUTCDate(activeCutoff.getUTCDate() - 30);
+
+  const activeUsers = USERS.filter(
+    (profile) =>
+      new Date(profile.lastActiveAt).getTime() >= activeCutoff.getTime()
+  ).length;
+
+  const activeHouses = CORNERS.filter((corner) => corner.active).length;
+
+  const booksPublished = LISTINGS.filter(
+    (listing) => listing.category === 'book' || listing.category === 'sale'
+  ).length;
+
+  const hotSearches = computeHotSearches();
+  const topContributors = computeTopContributors();
+  const activeHousesMap = CORNERS.filter((corner) => corner.active)
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name, 'es'))
+    .map((corner) => ({
+      top: `${corner.map.top}%`,
+      left: `${corner.map.left}%`,
+    }));
+
+  return {
+    kpis: {
+      exchanges,
+      activeHouses,
+      activeUsers,
+      booksPublished,
+    },
+    trendExchanges: TREND_EXCHANGES.slice(),
+    trendNewBooks: TREND_NEW_BOOKS.slice(),
+    topContributors,
+    hotSearches,
+    activeHousesMap,
+  };
+}
+
+function computeHotSearches(): HotSearch[] {
+  const counts = new Map<string, number>();
+
+  for (const listing of LISTINGS) {
+    for (const tag of listing.searchTags) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+
+  for (const seed of POPULAR_SEARCH_SEED) {
+    if (!counts.has(seed.term)) {
+      counts.set(seed.term, seed.weight);
+    } else {
+      counts.set(seed.term, (counts.get(seed.term) ?? 0) + seed.weight);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => {
+      if (b[1] !== a[1]) {
+        return b[1] - a[1];
+      }
+      return a[0].localeCompare(b[0], 'es');
+    })
+    .slice(0, 6)
+    .map(([term, count]) => ({ term, count }));
+}
+
+function computeTopContributors(): TopContributor[] {
+  const byExchanges = USERS.slice().sort((a, b) => {
+    if (b.exchangesCompleted !== a.exchangesCompleted) {
+      return b.exchangesCompleted - a.exchangesCompleted;
+    }
+    return a.username.localeCompare(b.username, 'es');
+  });
+
+  const byBooks = USERS.slice().sort((a, b) => {
+    if (b.booksPublished !== a.booksPublished) {
+      return b.booksPublished - a.booksPublished;
+    }
+    return a.username.localeCompare(b.username, 'es');
+  });
+
+  const results: TopContributor[] = [];
+  const seen = new Set<string>();
+
+  for (const profile of byExchanges.slice(0, 3)) {
+    results.push({
+      username: profile.username,
+      metric: 'exchanges',
+      value: profile.exchangesCompleted,
+    });
+    seen.add(profile.id);
+  }
+
+  for (const profile of byBooks) {
+    if (results.length >= 5) {
+      break;
+    }
+    if (seen.has(profile.id)) {
+      continue;
+    }
+    results.push({
+      username: profile.username,
+      metric: 'books',
+      value: profile.booksPublished,
+    });
+    seen.add(profile.id);
+  }
+
+  return results;
+}
+
+function buildCommunityActivity(): ActivityItem[] {
+  return USERS.slice()
+    .sort((a, b) => {
+      const diff =
+        new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime();
+      if (diff !== 0) {
+        return diff;
+      }
+      return a.username.localeCompare(b.username, 'es');
+    })
+    .slice(0, 6)
+    .map((profile) => ({
+      id: profile.id,
+      user: profile.displayName,
+      avatar: profile.avatar,
+    }));
+}
+
+function buildCommunitySuggestions(): SuggestionItem[] {
+  const priorityBarrios = new Set(['Palermo', 'Villa Crespo', 'Chacarita']);
+
+  const scored = USERS.map((profile) => {
+    let score = 0;
+    if (priorityBarrios.has(profile.barrio)) {
+      score += 3;
+    } else if (profile.city === 'Buenos Aires') {
+      score += 1;
+    }
+    if (profile.languages.includes('en')) {
+      score += 2;
+    }
+    if (profile.languages.includes('pt')) {
+      score += 1;
+    }
+    score += Math.floor(profile.exchangesCompleted / 5);
+
+    return { profile, score };
+  });
+
+  return scored
+    .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      return a.profile.username.localeCompare(b.profile.username, 'es');
+    })
+    .slice(0, 5)
+    .map(({ profile }) => ({
+      id: profile.id,
+      user: `${profile.displayName} · ${profile.barrio}`,
+      avatar: profile.avatar,
+    }));
+}
+
+function cloneStats(stats: CommunityStats): CommunityStats {
+  return {
+    kpis: { ...stats.kpis },
+    trendExchanges: stats.trendExchanges.slice(),
+    trendNewBooks: stats.trendNewBooks.slice(),
+    topContributors: stats.topContributors.map((item) => ({ ...item })),
+    hotSearches: stats.hotSearches.map((item) => ({ ...item })),
+    activeHousesMap: stats.activeHousesMap.map((pin) => ({ ...pin })),
+  };
+}

--- a/backend/tests/routes/community.api.test.ts
+++ b/backend/tests/routes/community.api.test.ts
@@ -1,0 +1,232 @@
+import request from 'supertest';
+import { describe, expect, test } from 'vitest';
+
+import app from '../../src/app.js';
+
+describe('community stats endpoint', () => {
+  test('returns deterministic community metrics', async () => {
+    const response = await request(app).get('/api/community/stats').expect(200);
+
+    expect(response.body).toEqual({
+      kpis: {
+        exchanges: 73,
+        activeHouses: 5,
+        activeUsers: 5,
+        booksPublished: 8,
+      },
+      trendExchanges: [36, 42, 45, 51, 58, 64, 72],
+      trendNewBooks: [18, 21, 24, 22, 27, 29, 33],
+      topContributors: [
+        { username: '@marcos', metric: 'exchanges', value: 21 },
+        { username: '@sofi', metric: 'exchanges', value: 18 },
+        { username: '@aylen', metric: 'exchanges', value: 15 },
+        { username: '@lucia', metric: 'books', value: 14 },
+        { username: '@valen', metric: 'books', value: 5 },
+      ],
+      hotSearches: [
+        { term: 'ensayo feminista', count: 5 },
+        { term: 'fantasia juvenil', count: 4 },
+        { term: 'ciencia ficcion argentina', count: 3 },
+        { term: 'club de lectura', count: 3 },
+        { term: 'clásicos', count: 2 },
+        { term: 'cronica urbana', count: 2 },
+      ],
+      activeHousesMap: [
+        { top: '68%', left: '35%' },
+        { top: '51%', left: '46%' },
+        { top: '47%', left: '41%' },
+        { top: '44%', left: '53%' },
+        { top: '42%', left: '58%' },
+      ],
+    });
+  });
+});
+
+describe('community feed endpoint', () => {
+  test('returns the latest feed slice with defaults', async () => {
+    const response = await request(app).get('/api/community/feed').expect(200);
+
+    expect(response.body).toHaveLength(8);
+    expect(response.body[0]).toEqual({
+      id: 'listing-1',
+      type: 'book',
+      user: 'Sofía M.',
+      avatar: 'https://images.entrelibros.org/avatars/sofia-m.png',
+      time: 'hace 1 d',
+      likes: 42,
+      corner: { id: 'corner-1', name: 'Rincón Plaza Malabia' },
+      title: 'Los años felices',
+      author: 'Claudia Piñeiro',
+      cover: 'https://images.entrelibros.org/books/anios-felices.jpg',
+    });
+    expect(response.body[1]).toEqual({
+      id: 'listing-2',
+      type: 'sale',
+      user: 'Marcos R.',
+      avatar: 'https://images.entrelibros.org/avatars/marcos-r.png',
+      time: 'hace 1 d',
+      likes: 35,
+      corner: { id: 'corner-2', name: 'Bibliorincón Parque Patricios' },
+      title: 'La invención de la naturaleza',
+      price: 12000,
+      condition: 'como nuevo',
+      cover: 'https://images.entrelibros.org/books/invencion-naturaleza.jpg',
+    });
+    expect(response.body[2]).toEqual({
+      id: 'listing-3',
+      type: 'seeking',
+      user: 'Lucía F.',
+      avatar: 'https://images.entrelibros.org/avatars/lucia-f.png',
+      time: 'hace 2 d',
+      likes: 21,
+      corner: { id: 'corner-5', name: 'Punto de Lectura Villa Crespo' },
+      title: 'Busco: Antología Poesía Mapuche',
+    });
+  });
+
+  test('supports pagination slices', async () => {
+    const response = await request(app)
+      .get('/api/community/feed')
+      .query({ page: 1, size: 3 })
+      .expect(200);
+
+    expect(response.body).toEqual([
+      {
+        id: 'listing-4',
+        type: 'book',
+        user: 'Aylén P.',
+        avatar: 'https://images.entrelibros.org/avatars/aylen-p.png',
+        time: 'hace 3 d',
+        likes: 29,
+        corner: { id: 'corner-3', name: 'Club de Lectura Chacarita' },
+        title: 'El jardín secreto',
+        author: 'Frances Hodgson Burnett',
+        cover: 'https://images.entrelibros.org/books/jardin-secreto.jpg',
+      },
+      {
+        id: 'listing-5',
+        type: 'sale',
+        user: 'Sofía M.',
+        avatar: 'https://images.entrelibros.org/avatars/sofia-m.png',
+        time: 'hace 5 d',
+        likes: 18,
+        corner: { id: 'corner-1', name: 'Rincón Plaza Malabia' },
+        title: 'Astroguía del Cono Sur',
+        price: 6800,
+        condition: 'usado',
+        cover: 'https://images.entrelibros.org/books/astroguia-conosur.jpg',
+      },
+      {
+        id: 'listing-6',
+        type: 'book',
+        user: 'Marcos R.',
+        avatar: 'https://images.entrelibros.org/avatars/marcos-r.png',
+        time: 'hace 5 d',
+        likes: 24,
+        corner: { id: 'corner-6', name: 'Rincón Colegiales' },
+        title: 'Invasión 2040',
+        author: 'Liliana Bodoc',
+        cover: 'https://images.entrelibros.org/books/invasion-2040.jpg',
+      },
+    ]);
+  });
+
+  test('validates pagination input', async () => {
+    const response = await request(app)
+      .get('/api/community/feed')
+      .query({ page: -1 })
+      .expect(400);
+
+    expect(response.body).toEqual({
+      error: 'BadRequest',
+      message: 'community.errors.invalid_pagination',
+    });
+
+    const invalidSize = await request(app)
+      .get('/api/community/feed')
+      .query({ size: 0 })
+      .expect(400);
+
+    expect(invalidSize.body).toEqual({
+      error: 'BadRequest',
+      message: 'community.errors.invalid_pagination',
+    });
+  });
+});
+
+describe('community activity endpoint', () => {
+  test('returns recent avatars', async () => {
+    const response = await request(app)
+      .get('/api/community/activity')
+      .expect(200);
+
+    expect(response.body).toEqual([
+      {
+        id: 'user-1',
+        user: 'Sofía M.',
+        avatar: 'https://images.entrelibros.org/avatars/sofia-m.png',
+      },
+      {
+        id: 'user-2',
+        user: 'Marcos R.',
+        avatar: 'https://images.entrelibros.org/avatars/marcos-r.png',
+      },
+      {
+        id: 'user-3',
+        user: 'Lucía F.',
+        avatar: 'https://images.entrelibros.org/avatars/lucia-f.png',
+      },
+      {
+        id: 'user-4',
+        user: 'Aylén P.',
+        avatar: 'https://images.entrelibros.org/avatars/aylen-p.png',
+      },
+      {
+        id: 'user-5',
+        user: 'Diego L.',
+        avatar: 'https://images.entrelibros.org/avatars/diego-l.png',
+      },
+      {
+        id: 'user-6',
+        user: 'Valen C.',
+        avatar: 'https://images.entrelibros.org/avatars/valen-c.png',
+      },
+    ]);
+  });
+});
+
+describe('community suggestions endpoint', () => {
+  test('returns ranked suggestions', async () => {
+    const response = await request(app)
+      .get('/api/community/suggestions')
+      .expect(200);
+
+    expect(response.body).toEqual([
+      {
+        id: 'user-1',
+        user: 'Sofía M. · Palermo',
+        avatar: 'https://images.entrelibros.org/avatars/sofia-m.png',
+      },
+      {
+        id: 'user-2',
+        user: 'Marcos R. · Chacarita',
+        avatar: 'https://images.entrelibros.org/avatars/marcos-r.png',
+      },
+      {
+        id: 'user-4',
+        user: 'Aylén P. · Caballito',
+        avatar: 'https://images.entrelibros.org/avatars/aylen-p.png',
+      },
+      {
+        id: 'user-5',
+        user: 'Diego L. · Almagro',
+        avatar: 'https://images.entrelibros.org/avatars/diego-l.png',
+      },
+      {
+        id: 'user-3',
+        user: 'Lucía F. · Villa Crespo',
+        avatar: 'https://images.entrelibros.org/avatars/lucia-f.png',
+      },
+    ]);
+  });
+});

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -179,6 +179,7 @@ Feature 7.1 Métricas mínimas y tableros
 
 - [ ] S-7.1 Métricas mínimas (nº RdL activos, publicaciones activas, acuerdos confirmados, tiempo de descubrimiento) (Must, E1; BR-70)
   - Éxito: tablero básico visible a coordinación.
+  - Actualización 2025-11-01: se habilitaron los endpoints `/api/community/stats`, `/api/community/feed`, `/api/community/activity` y `/api/community/suggestions` con agregaciones deterministas (KPIs, tendencias, búsquedas y participantes), documentación OpenAPI y pruebas de regresión, dejando la información lista para tableros y SSR.
 - [ ] S-7.2 Indicadores por zona y actividad (Should, E2; BR-71)
   - Éxito: filtro por zona en tablero.
 - [ ] S-7.3 Embudos publicación→contacto→acuerdo→confirmación (Could, E3; BR-72)


### PR DESCRIPTION
## Summary
- provide deterministic community stats, activity, and suggestion aggregates sourced from shared mock datasets
- serve a paginated community feed backed by the same dataset and expose `/api/community/*` routes
- document the new schemas in `openapi.json`, extend regression tests, and update the product backlog entry

## Testing
- npm run test:backend *(fails: local Postgres is unavailable in CI sandbox)*
- npm run test:frontend
- npm run format:backend
- npm run format:frontend

------
https://chatgpt.com/codex/tasks/task_e_68e612b33a94832e88cd8b986c649806